### PR TITLE
Fix propagation on add buttons

### DIFF
--- a/src/pages/WorkshopDashboard.jsx
+++ b/src/pages/WorkshopDashboard.jsx
@@ -1064,7 +1064,11 @@ const WorkshopDashboard = () => {
                   {/* Botões de Adicionar */}
                   <div className="flex gap-2 mt-4">
                     <button
-                      onClick={() => {
+                      type="button"
+                      draggable="false"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
                         setSelectedBikeIndex(bikeIndex);
                         setShowServiceModal(true);
                       }}
@@ -1073,7 +1077,11 @@ const WorkshopDashboard = () => {
                       + Serviço
                     </button>
                     <button
-                      onClick={() => {
+                      type="button"
+                      draggable="false"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
                         setSelectedBikeIndex(bikeIndex);
                         setShowPartModal(true);
                       }}


### PR DESCRIPTION
## Summary
- stop drag events from closing order card when clicking add buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68451aebb544832e95f9114bd073c9f5