### PR TITLE
Add logging for WorkshopDashboard actions

### DIFF
--- a/src/pages/WorkshopDashboard.jsx
+++ b/src/pages/WorkshopDashboard.jsx
@@ -535,11 +535,12 @@ const WorkshopDashboard = () => {
           </div>
         </div>
 
-        <div
-          onClick={() => {
-            setSelectedOrder(order);
-            setShowModal(true);
-          }}
+          <div
+            onClick={() => {
+              console.log('order details opened', order.id);
+              setSelectedOrder(order);
+              setShowModal(true);
+            }}
         >
           <div className="flex flex-col gap-1">
             <p className="text-gray-700 text-sm">
@@ -1067,6 +1068,7 @@ const WorkshopDashboard = () => {
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
+                        console.log('add service clicked', bikeIndex);
                         setSelectedBikeIndex(bikeIndex);
                         setShowServiceModal(true);
                       }}
@@ -1078,6 +1080,7 @@ const WorkshopDashboard = () => {
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
+                        console.log('add part clicked', bikeIndex);
                         setSelectedBikeIndex(bikeIndex);
                         setShowPartModal(true);
                       }}
@@ -1675,11 +1678,14 @@ const WorkshopDashboard = () => {
           </main>
 
           {showModal && selectedOrder && (
-            <OrderDetails
-              order={selectedOrder}
-              onUpdate={handleOrderUpdate}
-              onClose={() => setShowModal(false)}
-            />
+              <OrderDetails
+                order={selectedOrder}
+                onUpdate={handleOrderUpdate}
+                onClose={() => {
+                  console.log('order details closed');
+                  setShowModal(false);
+                }}
+              />
           )}
         </div>
       </>


### PR DESCRIPTION
## Summary
- debug `+ Serviço` and `+ Peça` buttons to log bike index when clicked
- log when the order details modal is opened or closed

## Testing
- `npm run lint` *(fails: 92 errors)*
- `npm run dev` *(fails: process killed, server started)*

------
https://chatgpt.com/codex/tasks/task_e_6845216c3048832e97858d88de65106b