### PR TITLE
Update reports page style

### DIFF
--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Download } from "lucide-react";
+import { ArrowLeft, Download, BarChart3, Calendar, TrendingUp, DollarSign, Package } from "lucide-react";
 import { collection, query, getDocs, where, orderBy } from "firebase/firestore";
 import { db } from "../config/firebase";
 import {
@@ -17,7 +16,7 @@ import jsPDF from "jspdf";
 import "jspdf-autotable";
 
 const ReportsManagement = () => {
-  const navigate = useNavigate();
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const [loading, setLoading] = useState(true);
   const [reportType, setReportType] = useState("monthly");
   const [selectedService, setSelectedService] = useState("all");
@@ -33,6 +32,18 @@ const ReportsManagement = () => {
   };
   const [dateRange, setDateRange] = useState(getDefaultDateRange());
   const [reportData, setReportData] = useState([]);
+
+  const totalRevenue = reportData.reduce((sum, item) => sum + item.total, 0);
+  const totalServices = reportData.reduce((sum, item) => sum + item.quantity, 0);
+  const averageTicket = totalServices ? totalRevenue / totalServices : 0;
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme === "dark") {
+      setIsDarkMode(true);
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
 
   const loadServices = async () => {
     try {
@@ -264,167 +275,206 @@ const ReportsManagement = () => {
     });
   }, [reportType]);
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="bg-white shadow">
-        <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center">
+    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
+      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+        <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
+          <div className="container mx-auto px-4 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                <button
+                  onClick={() => window.history.back()}
+                  className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+                >
+                  <ArrowLeft className="w-5 h-5" />
+                </button>
+                <div className="flex items-center space-x-3">
+                  <div className="bg-gradient-to-r from-indigo-400 to-indigo-600 p-2 rounded-full">
+                    <BarChart3 className="w-6 h-6 text-white" />
+                  </div>
+                  <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Relatórios</h1>
+                </div>
+              </div>
               <button
-                onClick={() => navigate("/admin")}
-                className="mr-4 text-gray-600 hover:text-gray-900 flex items-center"
+                onClick={exportPDF}
+                className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white px-6 py-2 rounded-full transition-all transform hover:scale-105 shadow-lg inline-flex items-center space-x-2"
               >
-                <ArrowLeft className="w-5 h-5 mr-2" />
-                Voltar
+                <Download className="w-5 h-5" />
+                <span>Exportar PDF</span>
               </button>
-              <h1 className="text-2xl font-bold text-gray-900">Relatórios</h1>
-            </div>
-            <button
-              onClick={exportPDF}
-              className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 flex items-center"
-            >
-              <Download className="w-5 h-5 mr-2" />
-              Exportar PDF
-            </button>
-          </div>
-        </div>
-      </header>
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <div className="bg-white shadow rounded-lg p-6 mb-6">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Tipo de Relatório
-              </label>
-              <select
-                value={reportType}
-                onChange={(e) => setReportType(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-              >
-                <option value="daily">Diário</option>
-                <option value="weekly">Semanal</option>
-                <option value="monthly">Mensal</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Serviço
-              </label>
-              <select
-                value={selectedService}
-                onChange={(e) => setSelectedService(e.target.value)}
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-              >
-                <option value="all">Todos os serviços</option>
-                {services.map((service) => (
-                  <option key={service.id} value={service.id}>
-                    {service.nome}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Data Inicial
-              </label>
-              <input
-                type="date"
-                value={dateRange.start}
-                onChange={(e) =>
-                  setDateRange((prev) => ({ ...prev, start: e.target.value }))
-                }
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Data Final
-              </label>
-              <input
-                type="date"
-                value={dateRange.end}
-                onChange={(e) =>
-                  setDateRange((prev) => ({ ...prev, end: e.target.value }))
-                }
-                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-                max={new Date().toISOString().split("T")[0]}
-              />
             </div>
           </div>
-        </div>
+        </header>
 
-        {loading ? (
-          <div>Carregando...</div>
-        ) : (
-          <>
-            <div className="bg-white shadow rounded-lg p-6 mb-6">
-              <h2 className="text-lg font-medium text-gray-900 mb-4">
-                Resultados
-              </h2>
-              <div className="h-96">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={reportData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="period" />
-                    <YAxis />
-                    <Tooltip />
-                    <Legend />
-                    <Line
-                      type="monotone"
-                      dataKey="total"
-                      stroke="#2563eb"
-                      name="Valor Total (R$)"
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="quantity"
-                      stroke="#059669"
-                      name="Quantidade de Serviços"
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
+        <main className="container mx-auto px-4 py-8">
+          <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl mb-8">
+            <h2 className="text-lg font-bold text-gray-800 dark:text-white mb-4">Filtros do Relatório</h2>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Tipo de Relatório
+                </label>
+                <select
+                  value={reportType}
+                  onChange={(e) => setReportType(e.target.value)}
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                >
+                  <option value="daily">Diário</option>
+                  <option value="weekly">Semanal</option>
+                  <option value="monthly">Mensal</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Serviço</label>
+                <select
+                  value={selectedService}
+                  onChange={(e) => setSelectedService(e.target.value)}
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                >
+                  <option value="all">Todos os serviços</option>
+                  {services.map((service) => (
+                    <option key={service.id} value={service.id}>
+                      {service.nome}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Data Inicial</label>
+                <input
+                  type="date"
+                  value={dateRange.start}
+                  onChange={(e) => setDateRange((prev) => ({ ...prev, start: e.target.value }))}
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Data Final</label>
+                <input
+                  type="date"
+                  value={dateRange.end}
+                  onChange={(e) => setDateRange((prev) => ({ ...prev, end: e.target.value }))}
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                  max={new Date().toISOString().split("T")[0]}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+            <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-xl p-6 shadow-lg">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Receita Total</p>
+                  <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                    R$ {totalRevenue.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                  </p>
+                </div>
+                <div className="bg-green-100 dark:bg-green-900/30 p-3 rounded-full">
+                  <DollarSign className="w-6 h-6 text-green-600 dark:text-green-400" />
+                </div>
               </div>
             </div>
 
-            <div className="bg-white shadow rounded-lg p-6">
-              <h2 className="text-lg font-medium text-gray-900 mb-4">
-                Detalhamento
-              </h2>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead>
-                    <tr>
-                      <th className="px-6 py-3 bg-gray-50 text-left text-xs font-medium text-gray-500 uppercase">
-                        Período
-                      </th>
-                      <th className="px-6 py-3 bg-gray-50 text-right text-xs font-medium text-gray-500 uppercase">
-                        Quantidade
-                      </th>
-                      <th className="px-6 py-3 bg-gray-50 text-right text-xs font-medium text-gray-500 uppercase">
-                        Total
-                      </th>
+            <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-xl p-6 shadow-lg">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Total de Serviços</p>
+                  <p className="text-2xl font-bold text-gray-800 dark:text-white">{totalServices}</p>
+                </div>
+                <div className="bg-blue-100 dark:bg-blue-900/30 p-3 rounded-full">
+                  <Package className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-xl p-6 shadow-lg">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Ticket Médio</p>
+                  <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                    R$ {averageTicket.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                  </p>
+                </div>
+                <div className="bg-amber-100 dark:bg-amber-900/30 p-3 rounded-full">
+                  <TrendingUp className="w-6 h-6 text-amber-600 dark:text-amber-400" />
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-xl p-6 shadow-lg">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Período</p>
+                  <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                    {Math.ceil((new Date(dateRange.end) - new Date(dateRange.start)) / (1000 * 60 * 60 * 24 * 30))} meses
+                  </p>
+                </div>
+                <div className="bg-purple-100 dark:bg-purple-900/30 p-3 rounded-full">
+                  <Calendar className="w-6 h-6 text-purple-600 dark:text-purple-400" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl mb-8">
+            <h2 className="text-xl font-bold text-gray-800 dark:text-white mb-6">Resultados</h2>
+            <div className="h-64 bg-gray-100 dark:bg-gray-700 rounded-lg mb-6 flex items-center justify-center">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={reportData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="period" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Line type="monotone" dataKey="total" stroke="#2563eb" name="Valor Total (R$)" />
+                  <Line type="monotone" dataKey="quantity" stroke="#059669" name="Quantidade de Serviços" />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl">
+            <h2 className="text-xl font-bold text-gray-800 dark:text-white mb-6">Detalhamento</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-600">
+                    <th className="text-left py-3 px-4 font-semibold text-gray-800 dark:text-white">PERÍODO</th>
+                    <th className="text-center py-3 px-4 font-semibold text-gray-800 dark:text-white">QUANTIDADE</th>
+                    <th className="text-right py-3 px-4 font-semibold text-gray-800 dark:text-white">TOTAL</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {reportData.map((item, index) => (
+                    <tr
+                      key={index}
+                      className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                    >
+                      <td className="py-3 px-4 text-gray-800 dark:text-white">{item.period}</td>
+                      <td className="py-3 px-4 text-center text-gray-800 dark:text-white">{item.quantity}</td>
+                      <td className="py-3 px-4 text-right font-semibold text-gray-800 dark:text-white">
+                        R$ {item.total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {reportData.map((item, index) => (
-                      <tr key={index}>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {item.period}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900">
-                          {item.quantity}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900">
-                          R$ {item.total.toFixed(2)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t-2 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50">
+                    <td className="py-3 px-4 font-bold text-gray-800 dark:text-white">TOTAL GERAL</td>
+                    <td className="py-3 px-4 text-center font-bold text-gray-800 dark:text-white">{totalServices}</td>
+                    <td className="py-3 px-4 text-right font-bold text-amber-600 dark:text-amber-400 text-lg">
+                      R$ {totalRevenue.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
             </div>
-          </>
-        )}
-      </main>
+          </div>
+        </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- restyle the reports page with gradient background and dark mode support
- remove router dependency and make back button history-based
- show metrics cards and updated table styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e288dbf4832ebc44b9b1fbade906