### PR TITLE
Atualiza paleta de cores para brand

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,7 @@
   transition: filter 300ms;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em #10b981aa);
 }
 .logo.react:hover {
   filter: drop-shadow(0 0 2em #61dafbaa);

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #10b981;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #059669;
 }
 
 body {
@@ -47,7 +47,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #10b981;
 }
 button:focus,
 button:focus-visible {

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -90,8 +90,8 @@ export default function Admin() {
       icon: <Wrench className="w-8 h-8" />,
       title: "Ordens de Serviço",
       description: "Cadastrar e gerenciar ordens de serviço",
-      color: "from-amber-400 to-amber-600",
-      hoverColor: "hover:from-amber-500 hover:to-amber-700",
+      color: "from-brand-400 to-brand-600",
+      hoverColor: "hover:from-brand-500 hover:to-brand-700",
       path: "/admin/orders",
     },
     {
@@ -145,7 +145,7 @@ export default function Admin() {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -204,7 +204,7 @@ export default function Admin() {
             <p className="text-red-500 text-center mb-4">{statsError}</p>
           )}
           <div className="mb-12">
-            <div className="bg-gradient-to-r from-amber-400 to-amber-600 rounded-2xl p-8 text-white shadow-2xl">
+            <div className="bg-gradient-to-r from-brand-400 to-brand-600 rounded-2xl p-8 text-white shadow-2xl">
               <h2 className="text-3xl md:text-4xl font-bold mb-4">Bem-vindo ao Dashboard</h2>
               <p className="text-xl opacity-90 max-w-2xl">Gerencie todos os aspectos da Bikes & Go através desta central administrativa moderna e intuitiva.</p>
             </div>
@@ -255,12 +255,12 @@ export default function Admin() {
                     </div>
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
-                        <h4 className="text-xl font-bold text-gray-800 dark:text-white mb-2 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+                        <h4 className="text-xl font-bold text-gray-800 dark:text-white mb-2 group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
                           {module.title}
                         </h4>
                         <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">{module.description}</p>
                       </div>
-                      <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-amber-500 group-hover:translate-x-1 transition-all duration-300" />
+                      <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-brand-500 group-hover:translate-x-1 transition-all duration-300" />
                     </div>
                   </div>
                 </div>
@@ -272,7 +272,7 @@ export default function Admin() {
           <div className="container mx-auto px-4 py-6">
             <div className="flex flex-col md:flex-row items-center justify-between">
               <div className="flex items-center space-x-2 mb-4 md:mb-0">
-                <Bike className="w-5 h-5 text-amber-500" />
+                <Bike className="w-5 h-5 text-brand-500" />
                 <span className="text-gray-600 dark:text-gray-400">© 2025 Bikes & Go - Sistema Administrativo</span>
               </div>
               <div className="text-sm text-gray-500 dark:text-gray-500">Versão 2.0 - Última atualização: Janeiro 2025</div>

--- a/src/pages/AdminLogin.jsx
+++ b/src/pages/AdminLogin.jsx
@@ -78,7 +78,7 @@ const AdminLogin = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}> 
-      <div className="bg-gradient-to-br from-amber-50 via-orange-50 to-amber-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
+      <div className="bg-gradient-to-br from-brand-50 via-orange-50 to-brand-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
         <button
           onClick={toggleDarkMode}
           className="absolute top-4 right-4 p-2 rounded-full bg-white/80 dark:bg-gray-800/80 text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors shadow-md"
@@ -88,7 +88,7 @@ const AdminLogin = () => {
         </button>
 
         <div className="mb-8 relative">
-          <div className="absolute -inset-4 bg-amber-400 rounded-full blur-lg opacity-75 animate-pulse"></div>
+          <div className="absolute -inset-4 bg-brand-400 rounded-full blur-lg opacity-75 animate-pulse"></div>
           <div className="relative">
             <img src="/assets/logo.svg" alt="Bikes & Go" className="w-24 h-24" />
           </div>
@@ -98,7 +98,7 @@ const AdminLogin = () => {
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-2">Área Administrativa</h1>
             <p className="text-gray-600 dark:text-gray-400">
-              Acesse o painel de controle da <span className="text-amber-600 dark:text-amber-400">Bikes & Go</span>
+              Acesse o painel de controle da <span className="text-brand-600 dark:text-brand-400">Bikes & Go</span>
             </p>
           </div>
 
@@ -121,7 +121,7 @@ const AdminLogin = () => {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="seu@email.com"
-                  className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all"
+                  className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
                   required
                 />
               </div>
@@ -139,7 +139,7 @@ const AdminLogin = () => {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   placeholder="••••••••"
-                  className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all"
+                  className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
                   required
                 />
                 <button
@@ -158,14 +158,14 @@ const AdminLogin = () => {
                   id="remember-me"
                   name="remember-me"
                   type="checkbox"
-                  className="h-4 w-4 text-amber-500 focus:ring-amber-500 border-gray-300 rounded"
+                  className="h-4 w-4 text-brand-500 focus:ring-brand-500 border-gray-300 rounded"
                 />
                 <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
                   Lembrar-me
                 </label>
               </div>
               <div className="text-sm">
-                <a href="#" className="font-medium text-amber-600 hover:text-amber-500 dark:text-amber-400">
+                <a href="#" className="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400">
                   Esqueceu a senha?
                 </a>
               </div>
@@ -174,7 +174,7 @@ const AdminLogin = () => {
             <button
               type="submit"
               disabled={loading}
-              className="w-full bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 disabled:from-gray-400 disabled:to-gray-500 text-white py-3 px-4 rounded-lg font-medium transition-all transform hover:scale-105 shadow-lg flex items-center justify-center space-x-2 disabled:cursor-not-allowed"
+              className="w-full bg-gradient-to-r from-brand-500 to-brand-600 hover:from-brand-600 hover:to-brand-700 disabled:from-gray-400 disabled:to-gray-500 text-white py-3 px-4 rounded-lg font-medium transition-all transform hover:scale-105 shadow-lg flex items-center justify-center space-x-2 disabled:cursor-not-allowed"
             >
               {loading ? (
                 <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
@@ -190,7 +190,7 @@ const AdminLogin = () => {
           <div className="mt-8 text-center">
             <button
               onClick={() => navigate("/")}
-              className="text-gray-600 dark:text-gray-400 hover:text-amber-600 dark:hover:text-amber-400 inline-flex items-center space-x-1 transition-colors"
+              className="text-gray-600 dark:text-gray-400 hover:text-brand-600 dark:hover:text-brand-400 inline-flex items-center space-x-1 transition-colors"
             >
               <ArrowLeft className="w-4 h-4" />
               <span>Voltar para o site</span>
@@ -203,7 +203,7 @@ const AdminLogin = () => {
           <p className="mt-1">25 anos de tradição no ciclismo</p>
         </div>
 
-        <div className="fixed top-20 left-20 w-64 h-64 bg-amber-300 rounded-full blur-3xl opacity-20 animate-blob"></div>
+        <div className="fixed top-20 left-20 w-64 h-64 bg-brand-300 rounded-full blur-3xl opacity-20 animate-blob"></div>
         <div className="fixed bottom-20 right-20 w-80 h-80 bg-orange-300 rounded-full blur-3xl opacity-20 animate-blob animation-delay-2000"></div>
         <div className="fixed bottom-40 left-40 w-72 h-72 bg-yellow-300 rounded-full blur-3xl opacity-20 animate-blob animation-delay-4000"></div>
       </div>

--- a/src/pages/ConsultaOS.jsx
+++ b/src/pages/ConsultaOS.jsx
@@ -402,7 +402,7 @@ const ConsultaOS = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-amber-50 via-orange-50 to-amber-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-brand-50 via-orange-50 to-brand-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20">
           <div className="container mx-auto px-4 py-6">
             <div className="flex items-center justify-between">
@@ -456,7 +456,7 @@ const ConsultaOS = () => {
                       value={searchValue}
                       onChange={handleInputChange}
                       placeholder="OS-20241204B ou (85) 99999-9999"
-                      className="pl-12 w-full px-6 py-4 text-lg bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all"
+                      className="pl-12 w-full px-6 py-4 text-lg bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
                       maxLength={20}
                     />
                   </div>
@@ -465,7 +465,7 @@ const ConsultaOS = () => {
                 <button
                   type="submit"
                   disabled={loading}
-                  className="w-full bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 disabled:from-gray-400 disabled:to-gray-500 text-white py-4 px-8 rounded-xl font-bold text-lg transition-all transform hover:scale-105 shadow-lg disabled:transform-none disabled:cursor-not-allowed"
+                  className="w-full bg-gradient-to-r from-brand-500 to-brand-600 hover:from-brand-600 hover:to-brand-700 disabled:from-gray-400 disabled:to-gray-500 text-white py-4 px-8 rounded-xl font-bold text-lg transition-all transform hover:scale-105 shadow-lg disabled:transform-none disabled:cursor-not-allowed"
                 >
                   {loading ? "Consultando..." : "Consultar"}
                 </button>
@@ -588,7 +588,7 @@ const ConsultaOS = () => {
         <div className="fixed bottom-6 right-6 z-50">
           <button
             onClick={() => handleHistoryClick()}
-            className="bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-white p-4 rounded-full shadow-lg hover:shadow-xl transition-all transform hover:scale-110"
+            className="bg-gradient-to-r from-brand-500 to-brand-600 hover:from-brand-600 hover:to-brand-700 text-white p-4 rounded-full shadow-lg hover:shadow-xl transition-all transform hover:scale-110"
             title="Ver Histórico"
           >
             <History className="w-6 h-6" />

--- a/src/pages/CustomerList.jsx
+++ b/src/pages/CustomerList.jsx
@@ -419,7 +419,7 @@ const CustomerList = () => {
   return (
     <>
       <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-        <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+        <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -457,7 +457,7 @@ const CustomerList = () => {
                 placeholder="Buscar clientes..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                className="pl-10 w-full px-4 py-3 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
               />
             </div>
           </div>
@@ -510,7 +510,7 @@ const CustomerList = () => {
               >
                 <div className="flex items-start justify-between mb-4">
                   <div>
-                    <h3 className="text-lg font-bold text-gray-800 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+                    <h3 className="text-lg font-bold text-gray-800 dark:text-white group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
                       {customer.nome}
                     </h3>
                     <span className="text-xs text-gray-500 dark:text-gray-400">ID: {customer.id}</span>
@@ -570,7 +570,7 @@ const CustomerList = () => {
                           setSelectedCustomer(customer);
                           setShowAddBikeModal(true);
                         }}
-                        className="text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-2 py-1 rounded hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
+                        className="text-xs bg-brand-100 dark:bg-brand-900/30 text-brand-700 dark:text-brand-400 px-2 py-1 rounded hover:bg-brand-200 dark:hover:bg-brand-900/50 transition-colors"
                       >
                         Adicionar
                       </button>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -254,7 +254,7 @@ export default function Home() {
     <div className={`min-h-screen transition-colors duration-300 overflow-x-hidden ${isDarkMode ? "dark" : ""}`}>
       <div className="bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
         {/* Benefits Bar */}
-        <div className="bg-amber-500 dark:bg-amber-600 text-white py-2 overflow-hidden">
+        <div className="bg-brand-500 dark:bg-brand-600 text-white py-2 overflow-hidden">
           <div className="container mx-auto px-4">
             <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 animate-pulse">
               {benefits.map((benefit, index) => (
@@ -283,13 +283,13 @@ export default function Home() {
               </div>
               {/* Desktop Navigation */}
               <nav className="hidden md:flex items-center space-x-8">
-                <a href="#servicos" className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors">
+                <a href="#servicos" className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors">
                   Serviços
                 </a>
-                <a href="#faq" className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors">
+                <a href="#faq" className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors">
                   FAQ
                 </a>
-                <a href="#contato" className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors">
+                <a href="#contato" className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors">
                   Contato
                 </a>
                 <div className="flex items-center space-x-3">
@@ -317,7 +317,7 @@ export default function Home() {
                 </button>
                 <button
                   onClick={handleConsultarOS}
-                  className="bg-amber-500 text-white px-6 py-2 rounded-full hover:bg-amber-600 transition-colors font-medium"
+                  className="bg-brand-500 text-white px-6 py-2 rounded-full hover:bg-brand-600 transition-colors font-medium"
                 >
                   Consultar O.S.
                 </button>
@@ -336,16 +336,16 @@ export default function Home() {
                 <div className="flex flex-col space-y-4 pt-4">
                   <a
                     href="#servicos"
-                    className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors"
+                    className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors"
                   >
                     Serviços
                   </a>
-                  <a href="#faq" className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors">
+                  <a href="#faq" className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors">
                     FAQ
                   </a>
                   <a
                     href="#contato"
-                    className="text-gray-700 dark:text-gray-300 hover:text-amber-500 transition-colors"
+                    className="text-gray-700 dark:text-gray-300 hover:text-brand-500 transition-colors"
                   >
                     Contato
                   </a>
@@ -371,7 +371,7 @@ export default function Home() {
                   </div>
                   <button
                     onClick={handleConsultarOS}
-                    className="bg-amber-500 text-white px-6 py-2 rounded-full hover:bg-amber-600 transition-colors font-medium w-fit"
+                    className="bg-brand-500 text-white px-6 py-2 rounded-full hover:bg-brand-600 transition-colors font-medium w-fit"
                   >
                     Consultar O.S.
                   </button>
@@ -384,7 +384,7 @@ export default function Home() {
         {/* Hero Section */}
         <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
           <div className="absolute inset-0">
-            <div className="absolute inset-0 bg-gradient-to-br from-amber-400/90 via-amber-500/90 to-amber-600/90 z-10"></div>
+            <div className="absolute inset-0 bg-gradient-to-br from-brand-400/90 via-brand-500/90 to-brand-600/90 z-10"></div>
             <video
               ref={videoRef}
               className="w-full h-full object-cover"
@@ -408,7 +408,7 @@ export default function Home() {
           <div className="relative z-20 container mx-auto px-4 text-center text-white">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               25 Anos de
-              <span className="block bg-gradient-to-r from-amber-300 to-white bg-clip-text text-transparent">
+              <span className="block bg-gradient-to-r from-brand-300 to-white bg-clip-text text-transparent">
                 Paixão por Bikes
               </span>
             </h1>
@@ -452,7 +452,7 @@ export default function Home() {
               </div>
               <div className="relative max-w-4xl mx-auto">
                 {featuredProducts.length > 0 ? (
-                  <div className="bg-gradient-to-r from-amber-400 to-amber-500 rounded-2xl p-8 shadow-2xl">
+                  <div className="bg-gradient-to-r from-brand-400 to-brand-500 rounded-2xl p-8 shadow-2xl">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
                       <div>
                         <img
@@ -474,7 +474,7 @@ export default function Home() {
                               `Olá! Tenho interesse na ${featuredProducts[currentProduct].name}. Podem me dar mais informações?`,
                             )
                           }
-                          className="bg-white text-amber-600 px-6 py-3 rounded-full font-bold hover:bg-gray-100 transition-colors inline-flex items-center space-x-2"
+                          className="bg-white text-brand-600 px-6 py-3 rounded-full font-bold hover:bg-gray-100 transition-colors inline-flex items-center space-x-2"
                         >
                           <ShoppingCart className="w-5 h-5" />
                           <span>Tenho Interesse</span>
@@ -505,7 +505,7 @@ export default function Home() {
                       key={index}
                       onClick={() => setCurrentProduct(index)}
                       className={`w-3 h-3 rounded-full transition-all ${
-                        index === currentProduct ? "bg-amber-500" : "bg-gray-300 dark:bg-gray-600"
+                        index === currentProduct ? "bg-brand-500" : "bg-gray-300 dark:bg-gray-600"
                       }`}
                     />
                   ))}
@@ -535,7 +535,7 @@ export default function Home() {
                   }
                   className="group bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 cursor-pointer"
                 >
-                  <div className="text-amber-500 mb-4 group-hover:scale-110 transition-transform duration-300">
+                  <div className="text-brand-500 mb-4 group-hover:scale-110 transition-transform duration-300">
                     {service.icon}
                   </div>
                   <h3 className="text-xl font-bold text-gray-800 dark:text-white mb-3">{service.title}</h3>
@@ -569,9 +569,9 @@ export default function Home() {
                   >
                     <span className="font-semibold text-gray-800 dark:text-white">{faq.question}</span>
                     {expandedFaq === index ? (
-                      <ChevronUp className="w-5 h-5 text-amber-500" />
+                      <ChevronUp className="w-5 h-5 text-brand-500" />
                     ) : (
-                      <ChevronDown className="w-5 h-5 text-amber-500" />
+                      <ChevronDown className="w-5 h-5 text-brand-500" />
                     )}
                   </button>
                   {expandedFaq === index && (
@@ -594,7 +594,7 @@ export default function Home() {
               </h2>
             </div>
             <div className="max-w-4xl mx-auto relative">
-              <div className="bg-gradient-to-r from-amber-400 to-amber-500 rounded-2xl p-8 text-white shadow-2xl">
+              <div className="bg-gradient-to-r from-brand-400 to-brand-500 rounded-2xl p-8 text-white shadow-2xl">
                 <div className="flex items-center justify-center mb-4">
                   {[...Array(testimonials[currentTestimonial].rating)].map((_, i) => (
                     <Star key={i} className="w-6 h-6 fill-current" />
@@ -623,7 +623,7 @@ export default function Home() {
                     key={index}
                     onClick={() => setCurrentTestimonial(index)}
                     className={`w-3 h-3 rounded-full transition-all ${
-                      index === currentTestimonial ? "bg-amber-500" : "bg-gray-300 dark:bg-gray-600"
+                      index === currentTestimonial ? "bg-brand-500" : "bg-gray-300 dark:bg-gray-600"
                     }`}
                   />
                 ))}
@@ -669,14 +669,14 @@ export default function Home() {
               <div className="space-y-8">
                 <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4 mb-4">
-                    <MapPin className="w-6 h-6 text-amber-500" />
+                    <MapPin className="w-6 h-6 text-brand-500" />
                     <h3 className="text-xl font-bold text-gray-800 dark:text-white">Endereço</h3>
                   </div>
                 <p className="text-gray-600 dark:text-gray-300">Av. Exemplo, 1234 - Centro, Exemplo - XX</p>
                 </div>
                 <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4 mb-4">
-                    <Phone className="w-6 h-6 text-amber-500" />
+                    <Phone className="w-6 h-6 text-brand-500" />
                     <h3 className="text-xl font-bold text-gray-800 dark:text-white">Telefones</h3>
                   </div>
                   <p className="text-gray-600 dark:text-gray-300">
@@ -687,7 +687,7 @@ export default function Home() {
                 </div>
                 <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4 mb-4">
-                    <Clock className="w-6 h-6 text-amber-500" />
+                    <Clock className="w-6 h-6 text-brand-500" />
                     <h3 className="text-xl font-bold text-gray-800 dark:text-white">Horário</h3>
                   </div>
                   <p className="text-gray-600 dark:text-gray-300">
@@ -752,10 +752,10 @@ export default function Home() {
                     <button
                       key={index}
                       onClick={() => handleOfficeServiceClick(service)}
-                      className="text-left p-4 bg-gray-50 dark:bg-gray-700 hover:bg-amber-50 dark:hover:bg-amber-900/20 rounded-lg transition-colors border border-gray-200 dark:border-gray-600 hover:border-amber-300 dark:hover:border-amber-600"
+                      className="text-left p-4 bg-gray-50 dark:bg-gray-700 hover:bg-brand-50 dark:hover:bg-brand-900/20 rounded-lg transition-colors border border-gray-200 dark:border-gray-600 hover:border-brand-300 dark:hover:border-brand-600"
                     >
                       <div className="flex items-center space-x-3">
-                        <Wrench className="w-5 h-5 text-amber-500" />
+                        <Wrench className="w-5 h-5 text-brand-500" />
                         <span className="text-gray-800 dark:text-gray-200 font-medium">{service}</span>
                       </div>
                     </button>
@@ -817,7 +817,7 @@ export default function Home() {
                     }
                   })
                 }}
-                className="text-amber-500 hover:text-amber-400 transition-colors text-sm"
+                className="text-brand-500 hover:text-brand-400 transition-colors text-sm"
               >
                 Acesso Funcionários
               </button>

--- a/src/pages/HomeManagement.jsx
+++ b/src/pages/HomeManagement.jsx
@@ -220,7 +220,7 @@ export default function HomeManagement() {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -232,7 +232,7 @@ export default function HomeManagement() {
                   <ArrowLeft className="w-5 h-5" />
                 </button>
                 <div className="flex items-center space-x-3">
-                  <div className="bg-gradient-to-r from-amber-400 to-amber-600 p-2 rounded-full">
+                  <div className="bg-gradient-to-r from-brand-400 to-brand-600 p-2 rounded-full">
                     <Bike className="w-6 h-6 text-white" />
                   </div>
                   <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Gerenciar Home</h1>
@@ -257,7 +257,7 @@ export default function HomeManagement() {
                     type="checkbox"
                     checked={showFeatured}
                     onChange={toggleVisibility}
-                    className="w-5 h-5 text-amber-500 rounded focus:ring-amber-500"
+                    className="w-5 h-5 text-brand-500 rounded focus:ring-brand-500"
                   />
                   <span className="text-gray-800 dark:text-white font-medium">Exibir seção de produtos em destaque</span>
                 </label>
@@ -270,7 +270,7 @@ export default function HomeManagement() {
                     placeholder="Buscar produtos..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                   />
                 </div>
               </div>
@@ -296,9 +296,9 @@ export default function HomeManagement() {
                     </div>
                     <div className="p-6">
                       <div className="mb-4">
-                        <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">{product.category}</span>
+                        <span className="text-sm text-brand-600 dark:text-brand-400 font-medium">{product.category}</span>
                         <h3 className="text-xl font-bold text-gray-800 dark:text-white mt-1">{product.name}</h3>
-                        <p className="text-2xl font-bold text-amber-600 dark:text-amber-400 mt-2">{product.price}</p>
+                        <p className="text-2xl font-bold text-brand-600 dark:text-brand-400 mt-2">{product.price}</p>
                       </div>
                       <div className="flex items-center justify-between">
                         <div className="flex space-x-2">

--- a/src/pages/ManageHomePage.jsx
+++ b/src/pages/ManageHomePage.jsx
@@ -99,7 +99,7 @@ export default function ManageHomePage() {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -111,7 +111,7 @@ export default function ManageHomePage() {
                   <ArrowLeft className="w-5 h-5" />
                 </button>
                 <div className="flex items-center space-x-3">
-                  <div className="bg-gradient-to-r from-amber-400 to-amber-600 p-2 rounded-full">
+                  <div className="bg-gradient-to-r from-brand-400 to-brand-600 p-2 rounded-full">
                     <Bike className="w-6 h-6 text-white" />
                   </div>
                   <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Gerenciar Home</h1>
@@ -136,7 +136,7 @@ export default function ManageHomePage() {
                     type="checkbox"
                     checked={showFeaturedProducts}
                     onChange={(e) => setShowFeaturedProducts(e.target.checked)}
-                    className="w-5 h-5 text-amber-500 rounded focus:ring-amber-500"
+                    className="w-5 h-5 text-brand-500 rounded focus:ring-brand-500"
                   />
                   <span className="text-gray-800 dark:text-white font-medium">Exibir seção de produtos em destaque</span>
                 </label>
@@ -149,7 +149,7 @@ export default function ManageHomePage() {
                     placeholder="Buscar produtos..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                   />
                 </div>
                 <button className="p-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
@@ -178,8 +178,8 @@ export default function ManageHomePage() {
                         onClick={() => handleToggleFeatured(product.id)}
                         className={`p-2 rounded-full transition-colors ${
                           product.featured
-                            ? "bg-amber-500 text-white"
-                            : "bg-white/80 text-gray-600 hover:bg-amber-500 hover:text-white"
+                            ? "bg-brand-500 text-white"
+                            : "bg-white/80 text-gray-600 hover:bg-brand-500 hover:text-white"
                         }`}
                         title={product.featured ? "Remover dos destaques" : "Adicionar aos destaques"}
                       >
@@ -188,15 +188,15 @@ export default function ManageHomePage() {
                     </div>
                     {product.featured && (
                       <div className="absolute top-4 left-4">
-                        <span className="bg-amber-500 text-white px-2 py-1 rounded-full text-xs font-medium">Destaque</span>
+                        <span className="bg-brand-500 text-white px-2 py-1 rounded-full text-xs font-medium">Destaque</span>
                       </div>
                     )}
                   </div>
                   <div className="p-6">
                     <div className="mb-4">
-                      <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">{product.category}</span>
+                      <span className="text-sm text-brand-600 dark:text-brand-400 font-medium">{product.category}</span>
                       <h3 className="text-xl font-bold text-gray-800 dark:text-white mt-1">{product.name}</h3>
-                      <p className="text-2xl font-bold text-amber-600 dark:text-amber-400 mt-2">{product.price}</p>
+                      <p className="text-2xl font-bold text-brand-600 dark:text-brand-400 mt-2">{product.price}</p>
                     </div>
                     <div className="flex items-center justify-between">
                       <div className="flex space-x-2">

--- a/src/pages/ManageReceiptsPage.jsx
+++ b/src/pages/ManageReceiptsPage.jsx
@@ -93,7 +93,7 @@ export default function ManageReceiptsPage() {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -130,7 +130,7 @@ export default function ManageReceiptsPage() {
                         type="date"
                         value={formData.date}
                         onChange={(e) => handleInputChange("date", e.target.value)}
-                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                       />
                     </div>
                   </div>
@@ -142,7 +142,7 @@ export default function ManageReceiptsPage() {
                         type="tel"
                         value={formData.phone}
                         onChange={(e) => handleInputChange("phone", e.target.value)}
-                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                         placeholder="(85) 99999-9999"
                       />
                     </div>
@@ -158,7 +158,7 @@ export default function ManageReceiptsPage() {
                         type="text"
                         value={formData.name}
                         onChange={(e) => handleInputChange("name", e.target.value)}
-                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                         placeholder="Nome completo"
                       />
                     </div>
@@ -169,7 +169,7 @@ export default function ManageReceiptsPage() {
                       type="text"
                       value={formData.cpf}
                       onChange={(e) => handleInputChange("cpf", e.target.value)}
-                      className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                      className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                       placeholder="000.000.000-00"
                     />
                   </div>
@@ -182,7 +182,7 @@ export default function ManageReceiptsPage() {
                     <textarea
                       value={formData.address}
                       onChange={(e) => handleInputChange("address", e.target.value)}
-                      className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                      className="pl-10 w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                       rows={2}
                       placeholder="Endereço completo"
                     />
@@ -194,7 +194,7 @@ export default function ManageReceiptsPage() {
                   <select
                     value={formData.paymentMethod}
                     onChange={(e) => handleInputChange("paymentMethod", e.target.value)}
-                    className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                    className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                   >
                     <option value="">Selecionar...</option>
                     <option value="dinheiro">Dinheiro</option>
@@ -224,7 +224,7 @@ export default function ManageReceiptsPage() {
                             type="text"
                             value={item.description}
                             onChange={(e) => handleItemChange(index, "description", e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                             placeholder="Descrição"
                           />
                         </div>
@@ -233,7 +233,7 @@ export default function ManageReceiptsPage() {
                             type="number"
                             value={item.quantity}
                             onChange={(e) => handleItemChange(index, "quantity", e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                             placeholder="Qtd."
                           />
                         </div>
@@ -242,7 +242,7 @@ export default function ManageReceiptsPage() {
                             type="text"
                             value={item.unit}
                             onChange={(e) => handleItemChange(index, "unit", e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                             placeholder="Unit."
                           />
                         </div>
@@ -251,7 +251,7 @@ export default function ManageReceiptsPage() {
                             type="text"
                             value={item.price}
                             onChange={(e) => handleItemChange(index, "price", e.target.value)}
-                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                            className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                             placeholder="Preço"
                           />
                         </div>
@@ -318,7 +318,7 @@ export default function ManageReceiptsPage() {
                         <button className="p-2 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900/30 rounded-lg transition-colors">
                           <Download className="w-4 h-4" />
                         </button>
-                        <button className="p-2 text-amber-500 hover:bg-amber-100 dark:hover:bg-amber-900/30 rounded-lg transition-colors">
+                        <button className="p-2 text-brand-500 hover:bg-brand-100 dark:hover:bg-brand-900/30 rounded-lg transition-colors">
                           <Edit className="w-4 h-4" />
                         </button>
                         <button className="p-2 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-lg transition-colors">

--- a/src/pages/NewCustomer.jsx
+++ b/src/pages/NewCustomer.jsx
@@ -36,7 +36,7 @@ const NewCustomer = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 p-4">
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 p-4">
       <div className="max-w-xl mx-auto bg-white dark:bg-gray-800 rounded-xl shadow p-6">
         <button
           onClick={() => navigate("/admin/customers")}

--- a/src/pages/ReceiptsManagement.jsx
+++ b/src/pages/ReceiptsManagement.jsx
@@ -333,7 +333,7 @@ const ReceiptsManagement = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -475,7 +475,7 @@ const ReceiptsManagement = () => {
                         type="text"
                         value={item.descricao}
                         onChange={(e) => handleItemChange(index, "descricao", e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                         placeholder="Descrição"
                       />
                     </div>
@@ -484,7 +484,7 @@ const ReceiptsManagement = () => {
                         type="number"
                         value={item.qtd}
                         onChange={(e) => handleItemChange(index, "qtd", e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                         placeholder="Qtd."
                       />
                     </div>
@@ -493,7 +493,7 @@ const ReceiptsManagement = () => {
                         type="text"
                         value={item.unit}
                         onChange={(e) => handleItemChange(index, "unit", e.target.value)}
-                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                        className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                         placeholder="Unit."
                       />
                     </div>
@@ -506,7 +506,7 @@ const ReceiptsManagement = () => {
                             ? (Number(item.qtd) * Number(item.unit)).toFixed(2)
                             : ""
                         }
-                        className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                        className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent text-sm"
                         placeholder="Preço"
                       />
                     </div>
@@ -583,7 +583,7 @@ const ReceiptsManagement = () => {
                     <button
                       type="button"
                       onClick={() => handleEdit(receipt)}
-                      className="p-2 text-amber-500 hover:bg-amber-100 dark:hover:bg-amber-900/30 rounded-lg transition-colors"
+                      className="p-2 text-brand-500 hover:bg-brand-100 dark:hover:bg-brand-900/30 rounded-lg transition-colors"
                     >
                       <Edit className="w-4 h-4" />
                     </button>

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -276,7 +276,7 @@ const ReportsManagement = () => {
   }, [reportType]);
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -316,7 +316,7 @@ const ReportsManagement = () => {
                 <select
                   value={reportType}
                   onChange={(e) => setReportType(e.target.value)}
-                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 >
                   <option value="daily">Diário</option>
                   <option value="weekly">Semanal</option>
@@ -329,7 +329,7 @@ const ReportsManagement = () => {
                 <select
                   value={selectedService}
                   onChange={(e) => setSelectedService(e.target.value)}
-                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 >
                   <option value="all">Todos os serviços</option>
                   {services.map((service) => (
@@ -346,7 +346,7 @@ const ReportsManagement = () => {
                   type="date"
                   value={dateRange.start}
                   onChange={(e) => setDateRange((prev) => ({ ...prev, start: e.target.value }))}
-                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                 />
               </div>
 
@@ -356,7 +356,7 @@ const ReportsManagement = () => {
                   type="date"
                   value={dateRange.end}
                   onChange={(e) => setDateRange((prev) => ({ ...prev, end: e.target.value }))}
-                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                  className="w-full px-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent"
                   max={new Date().toISOString().split("T")[0]}
                 />
               </div>
@@ -398,8 +398,8 @@ const ReportsManagement = () => {
                     R$ {averageTicket.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                   </p>
                 </div>
-                <div className="bg-amber-100 dark:bg-amber-900/30 p-3 rounded-full">
-                  <TrendingUp className="w-6 h-6 text-amber-600 dark:text-amber-400" />
+                <div className="bg-brand-100 dark:bg-brand-900/30 p-3 rounded-full">
+                  <TrendingUp className="w-6 h-6 text-brand-600 dark:text-brand-400" />
                 </div>
               </div>
             </div>
@@ -465,7 +465,7 @@ const ReportsManagement = () => {
                   <tr className="border-t-2 border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50">
                     <td className="py-3 px-4 font-bold text-gray-800 dark:text-white">TOTAL GERAL</td>
                     <td className="py-3 px-4 text-center font-bold text-gray-800 dark:text-white">{totalServices}</td>
-                    <td className="py-3 px-4 text-right font-bold text-amber-600 dark:text-amber-400 text-lg">
+                    <td className="py-3 px-4 text-right font-bold text-brand-600 dark:text-brand-400 text-lg">
                       R$ {totalRevenue.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
                     </td>
                   </tr>

--- a/src/pages/ServiceOrdersPage.jsx
+++ b/src/pages/ServiceOrdersPage.jsx
@@ -110,7 +110,7 @@ export default function ServiceOrdersPage() {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -122,7 +122,7 @@ export default function ServiceOrdersPage() {
                   <ArrowLeft className="w-5 h-5" />
                 </button>
                 <div className="flex items-center space-x-3">
-                  <div className="bg-gradient-to-r from-amber-400 to-amber-600 p-2 rounded-full">
+                  <div className="bg-gradient-to-r from-brand-400 to-brand-600 p-2 rounded-full">
                     <Wrench className="w-6 h-6 text-white" />
                   </div>
                   <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Ordens de Serviço</h1>
@@ -136,7 +136,7 @@ export default function ServiceOrdersPage() {
                     placeholder="Buscar OS ou cliente..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent w-64"
+                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent w-64"
                   />
                 </div>
                 <button className="p-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
@@ -195,7 +195,7 @@ export default function ServiceOrdersPage() {
                     className="bg-white dark:bg-gray-700 rounded-lg p-4 border border-gray-200 dark:border-gray-600 hover:shadow-md transition-all cursor-pointer group"
                   >
                     <div className="flex items-start justify-between mb-3">
-                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
                         {order.id}
                       </h4>
                       <button className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
@@ -240,7 +240,7 @@ export default function ServiceOrdersPage() {
                     className="bg-white dark:bg-gray-700 rounded-lg p-4 border border-gray-200 dark:border-gray-600 hover:shadow-md transition-all cursor-pointer group"
                   >
                     <div className="flex items-start justify-between mb-3">
-                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
                         {order.id}
                       </h4>
                       <button className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
@@ -286,7 +286,7 @@ export default function ServiceOrdersPage() {
                     className="bg-white dark:bg-gray-700 rounded-lg p-4 border border-gray-200 dark:border-gray-600 hover:shadow-md transition-all cursor-pointer group"
                   >
                     <div className="flex items-start justify-between mb-3">
-                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+                      <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
                         {order.id}
                       </h4>
                       <button className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">

--- a/src/pages/ServicesManagement.jsx
+++ b/src/pages/ServicesManagement.jsx
@@ -55,7 +55,7 @@ const ServicesManagement = () => {
       "from-green-400 to-green-600",
       "from-purple-400 to-purple-600",
       "from-red-400 to-red-600",
-      "from-amber-400 to-amber-600",
+      "from-brand-400 to-brand-600",
       "from-indigo-400 to-indigo-600",
       "from-pink-400 to-pink-600",
       "from-teal-400 to-teal-600",
@@ -328,7 +328,7 @@ const ServicesManagement = () => {
 
   return (
     <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+      <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
         <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
           <div className="container mx-auto px-4 py-4">
             <div className="flex items-center justify-between">
@@ -390,8 +390,8 @@ const ServicesManagement = () => {
                   <p className="text-sm text-gray-600 dark:text-gray-400">Mais Caro</p>
                   <p className="text-2xl font-bold text-gray-800 dark:text-white">R$ {maxPrice}</p>
                 </div>
-                <div className="bg-amber-100 dark:bg-amber-900/30 p-3 rounded-full">
-                  <DollarSign className="w-6 h-6 text-amber-600 dark:text-amber-400" />
+                <div className="bg-brand-100 dark:bg-brand-900/30 p-3 rounded-full">
+                  <DollarSign className="w-6 h-6 text-brand-600 dark:text-brand-400" />
                 </div>
               </div>
             </div>

--- a/src/pages/WorkshopDashboard.jsx
+++ b/src/pages/WorkshopDashboard.jsx
@@ -688,7 +688,7 @@ const WorkshopDashboard = () => {
     return (
       <div className="bg-white dark:bg-gray-700 rounded-lg p-4 border border-gray-200 dark:border-gray-600 hover:shadow-md transition-all cursor-pointer group mb-3">
         <div className="flex items-start justify-between mb-3">
-          <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors">
+          <h4 className="font-bold text-gray-800 dark:text-white group-hover:text-brand-600 dark:group-hover:text-brand-400 transition-colors">
             {order.codigo}
           </h4>
           <div className="relative">
@@ -1765,7 +1765,7 @@ const WorkshopDashboard = () => {
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-        <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
+        <div className="bg-gradient-to-br from-gray-50 via-brand-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
           {loading && (
             <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
               <div className="bg-white p-4 rounded-lg">
@@ -1785,7 +1785,7 @@ const WorkshopDashboard = () => {
                     <ArrowLeft className="w-5 h-5" />
                   </button>
                   <div className="flex items-center space-x-3">
-                    <div className="bg-gradient-to-r from-amber-400 to-amber-600 p-2 rounded-full">
+                    <div className="bg-gradient-to-r from-brand-400 to-brand-600 p-2 rounded-full">
                       <Wrench className="w-6 h-6 text-white" />
                     </div>
                     <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Ordens de Serviço</h1>
@@ -1800,7 +1800,7 @@ const WorkshopDashboard = () => {
                       placeholder="Buscar OS ou cliente..."
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
-                      className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent w-64"
+                      className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-transparent w-64"
                     />
                   </div>
                   <button className="p-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
@@ -1808,7 +1808,7 @@ const WorkshopDashboard = () => {
                   </button>
                   <button
                     onClick={handleLogout}
-                    className="text-gray-600 dark:text-gray-300 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"
+                    className="text-gray-600 dark:text-gray-300 hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
                   >
                     Sair
                   </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import colors from "tailwindcss/colors";
+
 export default {
   content: [
     "./index.html",
@@ -6,7 +8,11 @@ export default {
   ],
   darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: colors.emerald,
+      },
+    },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- extend Tailwind theme with `brand` emerald colors
- replace all `amber` Tailwind classes with the new brand palette
- adjust default CSS colors to use emerald values

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684915654544832ebdb57297821f0c37