### PR TITLE
Remove Firestore usage

### DIFF
--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -70,6 +70,8 @@ export function DataProvider({ children }) {
     },
   ]);
 
+  const [receipts, setReceipts] = useState([]);
+
   // --- Clientes CRUD ---
   const addCliente = async (cliente) => {
     setClientes((prev) => [...prev, cliente]);
@@ -261,10 +263,37 @@ export function DataProvider({ children }) {
     return completed[0] || null;
   };
 
+  // --- Recibos ---
+  const createReceipt = async (receipt) => {
+    setReceipts((prev) => [...prev, { id: Date.now().toString(), ...receipt }]);
+  };
+
+  const updateReceipt = async (id, updates) => {
+    setReceipts((prev) => prev.map((r) => (r.id === id ? { ...r, ...updates } : r)));
+  };
+
+  const deleteReceipt = async (id) => {
+    setReceipts((prev) => prev.filter((r) => r.id !== id));
+  };
+
+  const getReceipts = async () => receipts;
+
+  const getNextReceiptNumber = async () => {
+    const year = new Date().getFullYear();
+    const last = receipts
+      .filter((r) => r.numero && r.numero.endsWith(`-${year}`))
+      .sort((a, b) => b.numero.localeCompare(a.numero))[0];
+    const seq = (parseInt(last?.numero?.split("-")[0] || 0, 10) + 1)
+      .toString()
+      .padStart(3, "0");
+    return `${seq}-${year}`;
+  };
+
   const value = {
     clientes,
     servicos,
     ordensDeServico,
+    receipts,
     addCliente,
     updateCliente,
     deleteCliente,
@@ -289,6 +318,11 @@ export function DataProvider({ children }) {
     addObservation,
     getServices,
     getLatestCompletedOrderByPhone,
+    createReceipt,
+    updateReceipt,
+    deleteReceipt,
+    getReceipts,
+    getNextReceiptNumber,
   };
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;

--- a/src/hooks/useOrdens.js
+++ b/src/hooks/useOrdens.js
@@ -1,8 +1,9 @@
 // src/hooks/useOrdens.js
 import { useState } from "react";
-import { consultarOS } from "../config/firebase";
+import { useData } from "../contexts/DataContext";
 
 export const useOrdens = () => {
+  const { ordensDeServico } = useData();
   const [ordens, setOrdens] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -11,7 +12,18 @@ export const useOrdens = () => {
     setLoading(true);
     setError(null);
     try {
-      const resultado = await consultarOS(tipo, valor);
+      let resultado = [];
+      if (tipo === "historico") {
+        resultado = ordensDeServico.filter((o) =>
+          o.cliente?.telefone?.includes(valor)
+        );
+      } else if (tipo === "os") {
+        resultado = ordensDeServico.filter((o) => o.codigo === valor);
+      } else if (tipo === "telefone") {
+        resultado = ordensDeServico.filter((o) =>
+          o.cliente?.telefone?.includes(valor)
+        );
+      }
       setOrdens(resultado);
     } catch (err) {
       setError(err.message);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -29,7 +29,7 @@ import {
 import { useNavigate } from "react-router-dom"
 import { useAuth } from "../contexts/AuthContext"
 import { getFeaturedProducts, getHomeSettings } from "../services/homeService"
-import { getAllServicesOrdered } from "../services/serviceService"
+import { useServiceService } from "../services/serviceService"
 
 const normalizeDriveUrl = (url) => {
   if (!url) return url
@@ -128,6 +128,7 @@ export default function Home() {
   ]
 
   const [officeServices, setOfficeServices] = useState([])
+  const { getAllServicesOrdered } = useServiceService()
 
   useEffect(() => {
     const fetchServices = async () => {

--- a/src/pages/NewCustomer.jsx
+++ b/src/pages/NewCustomer.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { db } from "../config/firebase";
+import { useData } from "../contexts/DataContext";
 import { ArrowLeft } from "lucide-react";
 
 const NewCustomer = () => {
   const navigate = useNavigate();
+  const { addCliente } = useData();
   const [customer, setCustomer] = useState({
     nome: "",
     telefone: "",
@@ -21,9 +22,10 @@ const NewCustomer = () => {
     e.preventDefault();
     setLoading(true);
     try {
-      await addDoc(collection(db, "clientes"), {
+      await addCliente({
+        id: Date.now().toString(),
         ...customer,
-        dataCriacao: new Date(),
+        dataCriacao: new Date().toISOString(),
       });
       navigate("/admin/customers");
     } catch (error) {

--- a/src/pages/NewOrder.jsx
+++ b/src/pages/NewOrder.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { db } from "../config/firebase";
+import { useData } from "../contexts/DataContext";
 import { ArrowLeft, PlusCircle } from "lucide-react";
 import { jsPDF } from "jspdf";
 import "jspdf-autotable";
@@ -11,6 +11,15 @@ const logo = new URL("/assets/logo.svg", import.meta.url).href;
 
 function NewOrder() {
   const navigate = useNavigate();
+  const {
+    clientes,
+    servicos,
+    ordensDeServico,
+    addCliente,
+    addBikeToCliente,
+    addOrdem,
+    getServices,
+  } = useData();
 
   // -----------------------------
   // ESTADOS GERAIS
@@ -97,19 +106,7 @@ function NewOrder() {
   // -----------------------------
   async function loadServices() {
     try {
-      const servicosRef = collection(db, "servicos");
-      const snapshot = await getDocs(servicosRef);
-      const servicesData = {};
-
-      snapshot.forEach((docSnap) => {
-        const data = docSnap.data();
-        Object.entries(data).forEach(([nome, valor]) => {
-          // Remove R$, aspas e espaços, e troca vírgula por ponto
-          const valorLimpo = valor.replace(/['"R$\s]/g, "").replace(",", ".");
-          servicesData[nome] = parseFloat(valorLimpo);
-        });
-      });
-
+      const servicesData = await getServices();
       setAvailableServices(servicesData);
     } catch (err) {
       console.error("Erro ao carregar serviços:", err);
@@ -120,16 +117,10 @@ function NewOrder() {
   // Carrega bicicletas do cliente
   async function loadClientBikes(clientPhone) {
     try {
-      const bikesRef = collection(db, "clientes", clientPhone, "bikes");
-      const snapshot = await getDocs(bikesRef);
-      const bikesData = snapshot.docs.map((docSnap) => ({
-        id: docSnap.id,
-        ...docSnap.data(),
-      }));
-      setBikes(bikesData);
+      const cliente = clientes.find((c) => c.telefone === clientPhone);
+      setBikes(cliente?.bikes || []);
     } catch (err) {
       console.error("Erro ao carregar bicicletas:", err);
-      setError("Erro ao carregar bicicletas do cliente");
     }
   }
 
@@ -140,17 +131,15 @@ function NewOrder() {
     if (!telefone) return;
     try {
       setLoading(true);
-      const clientRef = doc(db, "clientes", telefone);
-      const clientDoc = await getDoc(clientRef);
-
-      if (clientDoc.exists()) {
-        setClientData(clientDoc.data());
+      const found = clientes.find((c) => c.telefone === telefone);
+      if (found) {
+        setClientData(found);
         await loadClientBikes(telefone);
       } else {
         setClientData(null);
         setBikes([]);
         setShowClientForm(true);
-        setNewClient((prev) => ({ ...prev, telefone: telefone }));
+        setNewClient((prev) => ({ ...prev, telefone }));
       }
     } catch (err) {
       console.error("Erro ao buscar cliente:", err);
@@ -168,12 +157,11 @@ function NewOrder() {
       }
       setLoading(true);
 
-      const clientRef = doc(db, "clientes", newClient.telefone);
-      await setDoc(clientRef, {
+      await addCliente({
+        id: Date.now().toString(),
         ...newClient,
-        dataCriacao: serverTimestamp(),
+        dataCriacao: new Date().toISOString(),
       });
-
       setClientData(newClient);
       setShowClientForm(false);
       await loadClientBikes(newClient.telefone);
@@ -192,12 +180,10 @@ function NewOrder() {
   async function handleAddBike() {
     try {
       setLoading(true);
-      const bikesRef = collection(db, "clientes", telefone, "bikes");
-      await addDoc(bikesRef, {
+      await addBikeToCliente(telefone, {
+        id: Date.now().toString(),
         ...newBike,
-        dataCriacao: serverTimestamp(),
       });
-
       await loadClientBikes(telefone);
       setNewBike({ marca: "", modelo: "", cor: "" });
       setShowBikeForm(false);
@@ -713,20 +699,8 @@ function NewOrder() {
       const ano = now.getFullYear();
       const mes = String(now.getMonth() + 1).padStart(2, "0");
 
-      const ordensRef = collection(db, "ordens");
-      const mesAtualQuery = query(
-        ordensRef,
-        where("codigo", ">=", `OS-${ano}${mes}`),
-        where("codigo", "<=", `OS-${ano}${mes}\uf8ff`),
-        orderBy("codigo", "desc"),
-        limit(1)
-      );
-
-      const mesAtualSnap = await getDocs(mesAtualQuery);
-      const ultimaOrdem = mesAtualSnap.docs[0]?.data();
-      const sequencial = (ultimaOrdem?.sequencial || 0) + 1;
-
-      const codigoOS = `OS-${ano}${mes}${String(sequencial).padStart(3, "0")}`;
+      const sequencial = ordensDeServico.length + 1;
+      const codigoOS = String(sequencial).padStart(3, "0");
       const urlOS = `${window.location.origin}/consulta?os=${codigoOS}`;
 
       // Prepara as bicicletas selecionadas
@@ -795,8 +769,7 @@ function NewOrder() {
         dataAtualizacao: new Date().toISOString(),
       };
 
-      // Salva no Firestore
-      await addDoc(ordensRef, newOrder);
+      await addOrdem({ id: Date.now().toString(), ...newOrder });
 
       // Armazena a ordem para imprimir
       setCreatedOrder(newOrder);

--- a/src/pages/ReceiptsManagement.jsx
+++ b/src/pages/ReceiptsManagement.jsx
@@ -13,16 +13,10 @@ import {
   Phone,
   MapPin,
 } from "lucide-react";
-import { db } from "../config/firebase";
 import jsPDF from "jspdf";
 import "jspdf-autotable";
-import {
-  createReceipt,
-  getReceipts,
-  updateReceipt,
-  deleteReceipt,
-  getNextReceiptNumber,
-} from "../services/receiptService";
+import { useData } from "../contexts/DataContext";
+import { useReceiptService } from "../services/receiptService";
 import { useOrderService } from "../services/orderService";
 const storeInfo = {
   name: "Bikes & Go",
@@ -55,6 +49,14 @@ const emptyForm = {
 const ReceiptsManagement = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { clientes } = useData();
+  const {
+    createReceipt,
+    getReceipts,
+    updateReceipt,
+    deleteReceipt,
+    getNextReceiptNumber,
+  } = useReceiptService();
   const { getLatestCompletedOrderByPhone } = useOrderService();
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [form, setForm] = useState({
@@ -100,10 +102,8 @@ const ReceiptsManagement = () => {
     const phone = rawPhone ? String(rawPhone) : "";
     if (!phone) return;
     try {
-      const clientRef = doc(db, "clientes", phone);
-      const snapshot = await getDoc(clientRef);
-      if (snapshot.exists()) {
-        const data = snapshot.data();
+      const data = clientes.find((c) => c.telefone === phone);
+      if (data) {
         setForm((prev) => ({
           ...prev,
           nome: data.nome || "",

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { ArrowLeft, Download, BarChart3, Calendar, TrendingUp, DollarSign, Package } from "lucide-react";
-import { db } from "../config/firebase";
+import { useData } from "../contexts/DataContext";
 import {
   LineChart,
   Line,
@@ -15,6 +15,7 @@ import jsPDF from "jspdf";
 import "jspdf-autotable";
 
 const ReportsManagement = () => {
+  const { servicos, ordensDeServico } = useData();
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [loading, setLoading] = useState(true);
   const [reportType, setReportType] = useState("monthly");
@@ -45,26 +46,12 @@ const ReportsManagement = () => {
   }, []);
 
   const loadServices = async () => {
-    try {
-      const servicosRef = collection(db, "servicos");
-      const querySnapshot = await getDocs(servicosRef);
-      const servicosData = [];
-
-      querySnapshot.forEach((doc) => {
-        const data = doc.data();
-        Object.keys(data).forEach((serviceName) => {
-          servicosData.push({
-            id: serviceName, // Usando o nome como ID
-            nome: serviceName,
-            valor: data[serviceName],
-          });
-        });
-      });
-
-      setServices(servicosData);
-    } catch (error) {
-      console.error("Erro ao carregar serviços:", error);
-    }
+    const servicosData = servicos.map((s) => ({
+      id: s.id,
+      nome: s.nome,
+      valor: s.valor,
+    }));
+    setServices(servicosData);
   };
   const processOrders = (orders, type) => {
     try {
@@ -135,23 +122,15 @@ const ReportsManagement = () => {
   const loadReportData = async () => {
     setLoading(true);
     try {
-      const ordensRef = collection(db, "ordens");
-      let ordersQuery = query(ordensRef, orderBy("dataCriacao", "desc"));
-      const querySnapshot = await getDocs(ordersQuery);
-      
-      const orders = querySnapshot.docs
-        .map((doc) => {
-          const data = doc.data();
+      const orders = ordensDeServico
+        .slice()
+        .sort((a, b) => new Date(b.dataCriacao) - new Date(a.dataCriacao))
+        .map((data) => {
           let totalValor = 0;
           let totalServicos = 0;
-          
-          console.log("Processando ordem:", doc.id, data);
-  
+
           if (data.bicicletas?.length > 0) {
-            data.bicicletas.forEach((bike, index) => {
-              console.log(`Processando bicicleta ${index}:`, bike);
-              
-              // Processa valorServicos (formato antigo)
+            data.bicicletas.forEach((bike) => {
               if (bike.valorServicos) {
                 Object.entries(bike.valorServicos).forEach(([serviceName, valor]) => {
                   if (selectedService === "all" || serviceName === selectedService) {
@@ -159,18 +138,10 @@ const ReportsManagement = () => {
                     const servicoTotal = parseFloat(valor) * quantidade;
                     totalValor += servicoTotal;
                     totalServicos += quantidade;
-                    
-                    console.log(`Processando serviço (valorServicos) ${serviceName}:`, {
-                      valor,
-                      quantidade,
-                      servicoTotal,
-                      totalAcumulado: totalValor
-                    });
                   }
                 });
               }
-  
-              // Processa serviceValues (formato novo)
+
               if (bike.serviceValues) {
                 Object.entries(bike.serviceValues).forEach(([serviceName, serviceData]) => {
                   if (selectedService === "all" || serviceName === selectedService) {
@@ -179,31 +150,17 @@ const ReportsManagement = () => {
                     const servicoTotal = valor * quantidade;
                     totalValor += servicoTotal;
                     totalServicos += quantidade;
-                    
-                    console.log(`Processando serviço (serviceValues) ${serviceName}:`, {
-                      valor,
-                      quantidade,
-                      servicoTotal,
-                      totalAcumulado: totalValor
-                    });
                   }
                 });
               }
             });
           }
-  
-          console.log("Totais finais para ordem:", doc.id, {
-            valor: totalValor,
-            servicos: totalServicos
-          });
-  
+
           return {
-            id: doc.id,
-            data: data.dataCriacao ? 
-              (typeof data.dataCriacao === 'string' ? new Date(data.dataCriacao) : data.dataCriacao.toDate()) : 
-              new Date(),
+            id: data.id,
+            data: new Date(data.dataCriacao),
             valor: totalValor,
-            quantidade: totalServicos
+            quantidade: totalServicos,
           };
         })
         .filter((order) => {
@@ -212,9 +169,8 @@ const ReportsManagement = () => {
           endDate.setHours(23, 59, 59);
           return order.data >= startDate && order.data <= endDate;
         });
-  
+
       const processedData = processOrders(orders, reportType);
-      console.log("Dados processados:", processedData);
       setReportData(processedData);
     } catch (error) {
       console.error("Erro ao carregar dados:", error);

--- a/src/services/homeService.js
+++ b/src/services/homeService.js
@@ -1,56 +1,26 @@
-import { db } from "../config/firebase";
-import { uploadImage, deleteImageByUrl } from "./uploadImage";
+let featuredProducts = [
+  { id: '1', name: 'Bike A', price: '1000', image: '', category: 'bike' },
+];
+let homeSettings = { showFeaturedProducts: true };
 
-export const getFeaturedProducts = async () => {
-  const ref = collection(db, "featuredProducts");
-  const snap = await getDocs(ref);
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-};
-
+export const getFeaturedProducts = async () => featuredProducts;
 
 export const createFeaturedProduct = async ({ imageFile, ...data }) => {
-  const refCollection = collection(db, "featuredProducts");
-  let imageUrl = data.image || "";
-  if (imageFile) {
-    imageUrl = await uploadImage(imageFile);
-  }
-  const docRef = await addDoc(refCollection, {
-    ...data,
-    image: imageUrl,
-    createdAt: serverTimestamp(),
-  });
-  const snap = await getDoc(docRef);
-  return { id: docRef.id, ...snap.data() };
+  const product = { id: Date.now().toString(), ...data };
+  featuredProducts.push(product);
+  return product;
 };
 
-export const updateFeaturedProduct = async (id, { imageFile, ...data }) => {
-  const refDoc = doc(db, "featuredProducts", id);
-  const updates = { ...data, updatedAt: serverTimestamp() };
-  if (imageFile) {
-    const snap = await getDoc(refDoc);
-    const oldUrl = snap.data()?.image;
-    if (oldUrl) await deleteImageByUrl(oldUrl);
-    const url = await uploadImage(imageFile);
-    updates.image = url;
-  }
-  await updateDoc(refDoc, updates);
+export const updateFeaturedProduct = async (id, data) => {
+  featuredProducts = featuredProducts.map((p) => (p.id === id ? { ...p, ...data } : p));
 };
 
 export const deleteFeaturedProduct = async (id) => {
-  const ref = doc(db, "featuredProducts", id);
-  const snap = await getDoc(ref);
-  const url = snap.data()?.image;
-  if (url) await deleteImageByUrl(url);
-  await deleteDoc(ref);
+  featuredProducts = featuredProducts.filter((p) => p.id !== id);
 };
 
-export const getHomeSettings = async () => {
-  const ref = doc(db, "home", "settings");
-  const snap = await getDoc(ref);
-  return snap.exists() ? snap.data() : { showFeaturedProducts: true };
-};
+export const getHomeSettings = async () => homeSettings;
 
 export const updateHomeSettings = async (data) => {
-  const ref = doc(db, "home", "settings");
-  await setDoc(ref, data, { merge: true });
+  homeSettings = { ...homeSettings, ...data };
 };

--- a/src/services/receiptService.js
+++ b/src/services/receiptService.js
@@ -1,46 +1,21 @@
+import { useData } from "../contexts/DataContext";
 
-import { db } from "../config/firebase";
+export function useReceiptService() {
+  const {
+    receipts,
+    createReceipt,
+    updateReceipt,
+    deleteReceipt,
+    getReceipts,
+    getNextReceiptNumber,
+  } = useData();
 
-export const createReceipt = async (data) => {
-  const ref = collection(db, "recibos");
-  const docRef = await addDoc(ref, { ...data, createdAt: serverTimestamp() });
-  const snapshot = await getDoc(docRef);
-  return { id: docRef.id, ...snapshot.data() };
-};
-
-export const getReceipts = async () => {
-  const ref = collection(db, "recibos");
-  const q = query(ref, orderBy("createdAt", "desc"));
-  const snap = await getDocs(q);
-  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-};
-
-export const updateReceipt = async (id, data) => {
-  const ref = doc(db, "recibos", id);
-  await updateDoc(ref, { ...data, updatedAt: serverTimestamp() });
-};
-
-export const deleteReceipt = async (id) => {
-  const ref = doc(db, "recibos", id);
-  await deleteDoc(ref);
-};
-
-export const getNextReceiptNumber = async () => {
-  const year = new Date().getFullYear();
-  const coll = collection(db, "recibos");
-  const q = query(
-    coll,
-    where("numero", ">=", `${year}-`),
-    where("numero", "<=", `${year}-\uf8ff`),
-    orderBy("numero", "desc"),
-    limit(1)
-  );
-  const snap = await getDocs(q);
-  const last = snap.docs[0]?.data();
-  const seq = (
-    parseInt(last?.numero?.split("-")[0] || 0, 10) + 1
-  )
-    .toString()
-    .padStart(3, "0");
-  return `${seq}-${year}`;
-};
+  return {
+    receipts,
+    createReceipt,
+    updateReceipt,
+    deleteReceipt,
+    getReceipts,
+    getNextReceiptNumber,
+  };
+}

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -1,15 +1,13 @@
-import { db } from "../config/firebase";
+import { useData } from "../contexts/DataContext";
 
-export const getAllServicesOrdered = async () => {
-  const snapshot = await getDocs(collection(db, "servicos"));
-  const services = [];
-  snapshot.forEach((doc) => {
-    const data = doc.data();
-    Object.entries(data).forEach(([nome, valor]) => {
-      const priceStr = String(valor).replace(/['"R$\s]/g, "").replace(",", ".");
-      services.push({ id: `${doc.id}_${nome}`, nome, valor: parseFloat(priceStr) });
-    });
-  });
-  services.sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
-  return services;
-};
+export function useServiceService() {
+  const { servicos } = useData();
+
+  const getAllServicesOrdered = async () => {
+    const list = servicos.map((s) => ({ id: s.id, nome: s.nome, valor: s.valor }));
+    list.sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+    return list;
+  };
+
+  return { getAllServicesOrdered };
+}


### PR DESCRIPTION
## Summary
- switch pages and hooks to use DataContext instead of Firestore
- manage receipts through context
- provide receipt service hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68491d5f4aa4832eba3c36bf5593f540