### PR TITLE
Adjust report date filter

### DIFF
--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -198,20 +198,31 @@ const ReportsManagement = () => {
             servicos: totalServicos
           });
   
+          const dataFinalizacao = data.dataAtualizacao
+            ? (typeof data.dataAtualizacao === 'string'
+                ? new Date(data.dataAtualizacao)
+                : data.dataAtualizacao.toDate())
+            : (typeof data.dataCriacao === 'string'
+                ? new Date(data.dataCriacao)
+                : data.dataCriacao.toDate());
+
           return {
             id: doc.id,
-            data: data.dataCriacao ? 
-              (typeof data.dataCriacao === 'string' ? new Date(data.dataCriacao) : data.dataCriacao.toDate()) : 
-              new Date(),
+            status: data.status,
+            data: dataFinalizacao,
             valor: totalValor,
-            quantidade: totalServicos
+            quantidade: totalServicos,
           };
         })
         .filter((order) => {
           const startDate = new Date(dateRange.start);
           const endDate = new Date(dateRange.end);
           endDate.setHours(23, 59, 59);
-          return order.data >= startDate && order.data <= endDate;
+          return (
+            order.status === 'Pronto' &&
+            order.data >= startDate &&
+            order.data <= endDate
+          );
         });
   
       const processedData = processOrders(orders, reportType);

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -216,10 +216,11 @@ const ReportsManagement = () => {
         })
         .filter((order) => {
           const startDate = new Date(dateRange.start);
+          startDate.setHours(0, 0, 0, 0);
           const endDate = new Date(dateRange.end);
-          endDate.setHours(23, 59, 59);
+          endDate.setHours(23, 59, 59, 999);
           return (
-            order.status === 'Pronto' &&
+            order.status?.toLowerCase() === 'pronto' &&
             order.data >= startDate &&
             order.data <= endDate
           );
@@ -267,13 +268,13 @@ const ReportsManagement = () => {
   }, [reportType, selectedService, dateRange]);
   useEffect(() => {
     const now = new Date();
-    let start = new Date();
+    let start = new Date(now);
     switch (reportType) {
       case "daily":
-        start.setDate(now.getDate() - 7);
+        // daily reports should default to the current day only
         break;
       case "weekly":
-        start.setDate(now.getDate() - 28);
+        start.setDate(now.getDate() - 7);
         break;
       case "monthly":
         start.setMonth(now.getMonth() - 6);


### PR DESCRIPTION
## Summary
- filter reports only on completed orders
- use the completion date (`dataAtualizacao`) when available for the range filter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684db5062d98832e8a6922945c00e169