### PR TITLE
Add optional quantity to order parts

### DIFF
--- a/src/pages/ConsultaOS.jsx
+++ b/src/pages/ConsultaOS.jsx
@@ -147,8 +147,9 @@ const ConsultaOS = () => {
       // Somar peças
       if (bike.pecas && bike.pecas.length > 0) {
         bike.pecas.forEach((peca) => {
+          const qty = parseInt(peca.quantidade) || 1;
           const valorPeca = parseFloat(peca.valor) || 0;
-          totalBike += valorPeca;
+          totalBike += valorPeca * qty;
         });
       }
 
@@ -380,10 +381,12 @@ const ConsultaOS = () => {
 
           doc.setFont("helvetica", "normal");
           bike.pecas.forEach((peca) => {
+            const qty = parseInt(peca.quantidade) || 1;
             const valorPeca = parseFloat(peca.valor) || 0;
-            totalBike += valorPeca;
-            doc.text(`• ${peca.nome}`, 20, yPos);
-            doc.text(`R$ ${valorPeca.toFixed(2)}`, 150, yPos);
+            const subtotal = valorPeca * qty;
+            totalBike += subtotal;
+            doc.text(`• ${peca.nome} (${qty}x)`, 20, yPos);
+            doc.text(`R$ ${subtotal.toFixed(2)}`, 150, yPos);
             yPos += 7;
           });
         }

--- a/src/pages/NewOrder.jsx
+++ b/src/pages/NewOrder.jsx
@@ -108,7 +108,8 @@ function NewOrder() {
     // Soma de peças
     Object.entries(selectedParts).forEach(([bikeId, partsArray]) => {
       partsArray.forEach((part) => {
-        total += parseFloat(part.valor) || 0;
+        const qty = parseInt(part.quantidade) || 1;
+        total += (parseFloat(part.valor) || 0) * qty;
       });
     });
 
@@ -283,13 +284,15 @@ function NewOrder() {
     setError(null);
 
     // Adiciona a peça no selectedParts
+    const quantidade = parseInt(partData.quantidade) || 1;
+
     setSelectedParts((prev) => {
       const currentBikeParts = prev[bikeId] || [];
       return {
         ...prev,
         [bikeId]: [
           ...currentBikeParts,
-          { nome: partData.nome, valor: partData.valor },
+          { nome: partData.nome, valor: partData.valor, quantidade },
         ],
       };
     });
@@ -297,7 +300,7 @@ function NewOrder() {
     // Limpa o formulário
     setNewPart((prev) => ({
       ...prev,
-      [bikeId]: { nome: "", valor: "" },
+      [bikeId]: { nome: "", valor: "", quantidade: "" },
     }));
   }
 
@@ -425,12 +428,14 @@ function NewOrder() {
 
         if (bike.pecas && bike.pecas.length > 0) {
           bike.pecas.forEach((peca) => {
+            const qty = parseInt(peca.quantidade) || 1;
             const valorPeca = Number.parseFloat(peca.valor) || 0;
-            totalBike += valorPeca;
+            const subtotal = valorPeca * qty;
+            totalBike += subtotal;
             docPDF.text(`  • ${peca.nome}`, 15, yPos);
-            docPDF.text(`1`, 125, yPos);
+            docPDF.text(`${qty}`, 125, yPos);
             docPDF.text(`${valorPeca.toFixed(2)}`, 145, yPos);
-            docPDF.text(`${valorPeca.toFixed(2)}`, 170, yPos);
+            docPDF.text(`${subtotal.toFixed(2)}`, 170, yPos);
             yPos += 4;
           });
         }
@@ -629,10 +634,12 @@ function NewOrder() {
               docPDF.addPage();
               yPos = 10;
             }
+            const qty = parseInt(peca.quantidade) || 1;
             const valorPeca = parseFloat(peca.valor || 0);
-            totalBike += valorPeca;
+            const subtotal = valorPeca * qty;
+            totalBike += subtotal;
             docPDF.text(
-              `• ${peca.nome} = R$ ${valorPeca.toFixed(2)}`,
+              `• ${peca.nome} (${qty}x) = R$ ${subtotal.toFixed(2)}`,
               10,
               yPos
             );
@@ -739,7 +746,8 @@ function NewOrder() {
           // Soma peças (do selectedParts)
           const bikeParts = selectedParts[bike.id] || [];
           const pecasTotal = bikeParts.reduce((acc, part) => {
-            return acc + (parseFloat(part.valor) || 0);
+            const qty = parseInt(part.quantidade) || 1;
+            return acc + (parseFloat(part.valor) || 0) * qty;
           }, 0);
 
           return {
@@ -1105,12 +1113,15 @@ function NewOrder() {
                     {bikeParts.length > 0 && (
                       <div className="mb-4">
                         <p className="font-bold">Peças já adicionadas:</p>
-                        <ul className="list-disc list-inside">
+                        <ul className="space-y-2">
                           {bikeParts.map((part, idx) => (
-                            <li key={idx} className="flex justify-between">
+                            <li
+                              key={idx}
+                              className="flex justify-between items-center border rounded p-2"
+                            >
                               <div>
-                                {part.nome} - R${" "}
-                                {parseFloat(part.valor).toFixed(2)}
+                                {part.nome} - {parseFloat(part.valor).toFixed(2)}
+                                {" "}({part.quantidade || 1}x)
                               </div>
                               <button
                                 onClick={() => handleRemovePart(bikeId, idx)}
@@ -1144,6 +1155,16 @@ function NewOrder() {
                         value={partForm.valor || ""}
                         onChange={(e) =>
                           handleNewPartChange(bikeId, "valor", e.target.value)
+                        }
+                      />
+                      <input
+                        type="number"
+                        placeholder="Quantidade"
+                        className="w-full px-3 py-2 border rounded"
+                        min="1"
+                        value={partForm.quantidade || ""}
+                        onChange={(e) =>
+                          handleNewPartChange(bikeId, "quantidade", e.target.value)
                         }
                       />
                       <button

--- a/src/pages/ReceiptsManagement.jsx
+++ b/src/pages/ReceiptsManagement.jsx
@@ -147,7 +147,7 @@ const ReceiptsManagement = () => {
             bike.pecas.forEach((peca) => {
               items.push({
                 descricao: peca.nome || peca.descricao || "Peça",
-                qtd: 1,
+                qtd: parseInt(peca.quantidade) || 1,
                 unit: parseFloat(peca.valor || 0),
               });
             });

--- a/src/pages/WorkshopDashboard.jsx
+++ b/src/pages/WorkshopDashboard.jsx
@@ -399,11 +399,13 @@ const WorkshopDashboard = () => {
               docPDF.addPage();
               yPos = 10;
             }
+            const qty = parseInt(peca.quantidade) || 1;
             const valorPeca = parseFloat(peca.valor || 0);
-            totalBike += valorPeca;
+            const subtotal = valorPeca * qty;
+            totalBike += subtotal;
 
             docPDF.text(
-              `- ${peca.nome} = R$ ${valorPeca.toFixed(2)}`,
+              `- ${peca.nome} (${qty}x) = R$ ${subtotal.toFixed(2)}`,
               10,
               yPos
             );
@@ -443,7 +445,8 @@ const WorkshopDashboard = () => {
         // Soma peças
         if (bike.pecas) {
           bike.pecas.forEach((peca) => {
-            subtotal += parseFloat(peca.valor || 0);
+            const qty = parseInt(peca.quantidade) || 1;
+            subtotal += (parseFloat(peca.valor || 0)) * qty;
           });
         }
         totalGeral += subtotal;
@@ -575,12 +578,14 @@ const WorkshopDashboard = () => {
 
         if (bike.pecas && bike.pecas.length > 0) {
           bike.pecas.forEach((peca) => {
+            const qty = parseInt(peca.quantidade) || 1;
             const valorPeca = Number.parseFloat(peca.valor) || 0;
-            totalBike += valorPeca;
+            const subtotal = valorPeca * qty;
+            totalBike += subtotal;
             docPDF.text(`  • ${peca.nome}`, 15, yPos);
-            docPDF.text(`1`, 125, yPos);
+            docPDF.text(`${qty}`, 125, yPos);
             docPDF.text(`${valorPeca.toFixed(2)}`, 145, yPos);
-            docPDF.text(`${valorPeca.toFixed(2)}`, 170, yPos);
+            docPDF.text(`${subtotal.toFixed(2)}`, 170, yPos);
             yPos += 4;
           });
         }
@@ -649,10 +654,10 @@ const WorkshopDashboard = () => {
     // Calcula o total das peças
     const calculatePartsTotal = (bike) => {
       if (!bike.pecas) return 0;
-      return bike.pecas.reduce(
-        (total, peca) => total + (parseFloat(peca.valor) || 0),
-        0
-      );
+      return bike.pecas.reduce((total, peca) => {
+        const qty = parseInt(peca.quantidade) || 1;
+        return total + (parseFloat(peca.valor) || 0) * qty;
+      }, 0);
     };
 
     // Calcula o total geral da ordem
@@ -1105,10 +1110,10 @@ const WorkshopDashboard = () => {
 
       // Soma peças
       if (bike.pecas) {
-        total += bike.pecas.reduce(
-          (sum, peca) => sum + parseFloat(peca.valor || 0),
-          0
-        );
+        total += bike.pecas.reduce((sum, peca) => {
+          const qty = parseInt(peca.quantidade) || 1;
+          return sum + (parseFloat(peca.valor || 0) * qty);
+        }, 0);
       }
 
       return total;
@@ -1249,14 +1254,14 @@ const WorkshopDashboard = () => {
                   {/* Lista de Peças */}
                   <div className="mt-3">
                     <p className="font-bold mb-1">Peças:</p>
-                    <ul className="list-disc list-inside">
+                    <ul className="space-y-2">
                       {bike.pecas?.map((peca, pecaIndex) => (
                         <li
                           key={pecaIndex}
-                          className="flex items-center justify-between py-1"
+                          className="flex items-center justify-between border rounded p-2"
                         >
                           <span>
-                            {peca.nome} - {formatCurrency(peca.valor)}
+                            {peca.nome} - {formatCurrency(peca.valor)} ({peca.quantidade || 1}x)
                           </span>
                           <div className="flex gap-2">
                             <button
@@ -1288,10 +1293,10 @@ const WorkshopDashboard = () => {
                     <div className="mt-2 text-right text-sm text-gray-600">
                       Subtotal Peças:{" "}
                       {formatCurrency(
-                        bike.pecas.reduce(
-                          (total, peca) => total + parseFloat(peca.valor || 0),
-                          0
-                        )
+                        bike.pecas.reduce((total, peca) => {
+                          const qty = parseInt(peca.quantidade) || 1;
+                          return total + (parseFloat(peca.valor || 0) * qty);
+                        }, 0)
                       )}
                     </div>
                   )}
@@ -1603,6 +1608,7 @@ const WorkshopDashboard = () => {
                     const updatedPart = {
                       nome: formData.get("nome"),
                       valor: parseFloat(formData.get("valor")),
+                      quantidade: parseInt(formData.get("quantidade")) || 1,
                     };
                     handleEditPart(
                       selectedBikeIndex,
@@ -1636,6 +1642,18 @@ const WorkshopDashboard = () => {
                       step="0.01"
                       className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500"
                       required
+                    />
+                  </div>
+                  <div className="mb-6">
+                    <label className="block text-gray-700 text-sm font-bold mb-2">
+                      Quantidade
+                    </label>
+                    <input
+                      type="number"
+                      name="quantidade"
+                      defaultValue={selectedPeca.quantidade || 1}
+                      min="1"
+                      className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500"
                     />
                   </div>
 
@@ -1676,6 +1694,7 @@ const WorkshopDashboard = () => {
                     const partData = {
                       nome: formData.get("nome"),
                       valor: parseFloat(formData.get("valor")),
+                      quantidade: parseInt(formData.get("quantidade")) || 1,
                     };
                     handleAddPart(selectedBikeIndex, partData);
                   }}
@@ -1703,6 +1722,17 @@ const WorkshopDashboard = () => {
                       step="0.01"
                       className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500"
                       required
+                    />
+                  </div>
+                  <div className="mb-6">
+                    <label className="block text-gray-700 text-sm font-bold mb-2">
+                      Quantidade
+                    </label>
+                    <input
+                      type="number"
+                      name="quantidade"
+                      min="1"
+                      className="w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-green-500"
                     />
                   </div>
 

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -83,12 +83,15 @@ export const updateOrderPart = async (orderId, bikeIndex, partIndex, updatedPart
 
     // Calcula a diferença de valor
     const pecaAntiga = bikes[bikeIndex].pecas[partIndex];
-    const diferencaValor = parseFloat(updatedPart.valor) - parseFloat(pecaAntiga.valor);
+    const oldSubtotal = (parseFloat(pecaAntiga.valor) || 0) * (parseInt(pecaAntiga.quantidade) || 1);
+    const newSubtotal = (parseFloat(updatedPart.valor) || 0) * (parseInt(updatedPart.quantidade) || 1);
+    const diferencaValor = newSubtotal - oldSubtotal;
     
     // Atualiza a peça
     bikes[bikeIndex].pecas[partIndex] = {
       ...updatedPart,
-      valor: parseFloat(updatedPart.valor)
+      valor: parseFloat(updatedPart.valor),
+      quantidade: parseInt(updatedPart.quantidade) || 1,
     };
     
     // Atualiza o valor total da ordem
@@ -339,11 +342,12 @@ export const addPartToBike = async (orderId, bikeIndex, newPart) => {
     // Adiciona a nova peça
     bikes[bikeIndex].pecas.push({
       ...newPart,
-      valor: parseFloat(newPart.valor)
+      valor: parseFloat(newPart.valor),
+      quantidade: parseInt(newPart.quantidade) || 1,
     });
-    
-    // Recalcula o total da ordem
-    const novoTotal = parseFloat(order.valorTotal || 0) + parseFloat(newPart.valor);
+
+    const subtotal = (parseFloat(newPart.valor) || 0) * (parseInt(newPart.quantidade) || 1);
+    const novoTotal = parseFloat(order.valorTotal || 0) + subtotal;
 
     await updateDoc(orderRef, { 
       bicicletas: bikes,
@@ -380,7 +384,8 @@ export const removeOrderPart = async (orderId, bikeIndex, partIndex) => {
 
     // Remove a peça e calcula o novo total
     const pecaRemovida = bikes[bikeIndex].pecas[partIndex];
-    const novoTotal = parseFloat(order.valorTotal || 0) - parseFloat(pecaRemovida.valor || 0);
+    const subtotal = (parseFloat(pecaRemovida.valor || 0)) * (parseInt(pecaRemovida.quantidade) || 1);
+    const novoTotal = parseFloat(order.valorTotal || 0) - subtotal;
     
     bikes[bikeIndex].pecas = bikes[bikeIndex].pecas.filter((_, idx) => idx !== partIndex);
 

--- a/src/utils/generateWorkshopTagsPDF.js
+++ b/src/utils/generateWorkshopTagsPDF.js
@@ -42,7 +42,8 @@ async function generateWorkshopTagsPDF(ordem) {
       }
       if (bike.pecas) {
         bike.pecas.forEach((peca) => {
-          subtotal += Number.parseFloat(peca.valor) || 0
+          const qty = parseInt(peca.quantidade) || 1
+          subtotal += (Number.parseFloat(peca.valor) || 0) * qty
         })
       }
       return subtotal
@@ -132,8 +133,10 @@ async function generateWorkshopTagsPDF(ordem) {
       docPDF.setFont("helvetica", "bold")
       if (bike.pecas && bike.pecas.length > 0) {
         bike.pecas.forEach((peca) => {
+          const qty = parseInt(peca.quantidade) || 1
           const valorPeca = Number.parseFloat(peca.valor) || 0
-          docPDF.text(`• ${peca.nome} = R$ ${valorPeca.toFixed(2)}`, x + 5, yPos)
+          const subtotal = valorPeca * qty
+          docPDF.text(`• ${peca.nome} (${qty}x) = R$ ${subtotal.toFixed(2)}`, x + 5, yPos)
           yPos += 3
         })
       } else {


### PR DESCRIPTION
## Summary
- allow specifying part quantity when creating or editing an order
- show quantity beside each part and separate parts with borders
- update totals and PDF generation to multiply part value by quantity
- propagate part quantities to receipts and order consultation pages

## Testing
- `npm run lint` *(fails: many prop-types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871ced76874832eaac712a464f1980e