### PR TITLE
feat: show OS numbers and add mechanic history

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -92,12 +92,18 @@ export const consultarOS = async (tipo, valor) => {
       const telefoneNumerico = valor.replace(/\D/g, "");
       console.log("Buscando pelo telefone:", telefoneNumerico);
 
-      // Filtra por telefone
-      q = query(
-        osRef,
-        where("cliente.telefone", "==", telefoneNumerico),
-        orderBy("dataCriacao", "desc"),
-      );
+      // Filtra por telefone completo ou sem DDD
+      q = telefoneNumerico.length === 9
+        ? query(
+            osRef,
+            where("cliente.telefoneSemDDD", "==", telefoneNumerico),
+            orderBy("dataCriacao", "desc"),
+          )
+        : query(
+            osRef,
+            where("cliente.telefone", "==", telefoneNumerico),
+            orderBy("dataCriacao", "desc"),
+          );
 
       const querySnapshot = await getDocs(q);
       querySnapshot.forEach((doc) => {
@@ -115,11 +121,17 @@ export const consultarOS = async (tipo, valor) => {
       }
 
       const telefoneNumerico = valor.replace(/\D/g, "");
-      q = query(
-        osRef,
-        where("cliente.telefone", "==", telefoneNumerico),
-        orderBy("dataCriacao", "desc"),
-      );
+      q = telefoneNumerico.length === 9
+        ? query(
+            osRef,
+            where("cliente.telefoneSemDDD", "==", telefoneNumerico),
+            orderBy("dataCriacao", "desc"),
+          )
+        : query(
+            osRef,
+            where("cliente.telefone", "==", telefoneNumerico),
+            orderBy("dataCriacao", "desc"),
+          );
 
       const querySnapshot = await getDocs(q);
       querySnapshot.forEach((doc) => {

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -32,10 +32,17 @@ const storage = getStorage(app);
 export const updateOrderStatus = async (orderId, newStatus) => {
   try {
     const orderRef = doc(db, "ordens", orderId);
-    await updateDoc(orderRef, {
+    const updateData = {
       status: newStatus,
       dataAtualizacao: serverTimestamp(),
-    });
+    };
+
+    // Registra a data de conclusão quando a ordem é marcada como pronta
+    if (newStatus === "Pronto") {
+      updateData.dataConclusao = serverTimestamp();
+    }
+
+    await updateDoc(orderRef, updateData);
     return true;
   } catch (error) {
     console.error("Erro ao atualizar status:", error);

--- a/src/pages/ConsultaOS.jsx
+++ b/src/pages/ConsultaOS.jsx
@@ -240,16 +240,13 @@ const ConsultaOS = () => {
 
       if (tipo === "telefone") {
         const telefoneNumerico = searchValue.replace(/\D/g, "");
-        if (telefoneNumerico.length < 10) {
+        if (telefoneNumerico.length < 9) {
           throw new Error("Telefone inválido");
         }
         sessionStorage.setItem("telefoneConsulta", telefoneNumerico);
       }
 
       if (tipo === "os") {
-        if (!sessionStorage.getItem("telefoneConsulta")) {
-          throw new Error("Por favor, faça primeiro uma busca por telefone");
-        }
         navigate(`/consulta?os=${searchValue}`);
       }
 
@@ -491,7 +488,7 @@ const ConsultaOS = () => {
                       id="search"
                       value={searchValue}
                       onChange={handleInputChange}
-                      placeholder="OS-20241204B ou (85) 99999-9999"
+                      placeholder="OS-20241204B ou 99999-9999"
                       className="pl-12 w-full px-6 py-4 text-lg bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-amber-500 focus:border-transparent transition-all"
                       maxLength={20}
                     />

--- a/src/pages/MechanicHistory.jsx
+++ b/src/pages/MechanicHistory.jsx
@@ -57,10 +57,13 @@ const MechanicHistory = () => {
         const orderServices = [];
         ordersSnap.forEach((doc) => {
           const data = doc.data();
-          if (data.status !== "Pronto") return;
-          const orderDate = data.dataAtualizacao
-            ? data.dataAtualizacao.toDate()
-            : data.dataCriacao.toDate();
+          if (data.status !== "Pronto" && data.status !== "Entregue") return;
+          const getDate = (field) =>
+            field ? (field.toDate ? field.toDate() : new Date(field)) : null;
+          const orderDate =
+            getDate(data.dataConclusao) ||
+            getDate(data.dataAtualizacao) ||
+            getDate(data.dataCriacao);
           if (data.bicicletas?.length > 0) {
             data.bicicletas.forEach((bike) => {
               if (bike.valorServicos) {

--- a/src/pages/MechanicHistory.jsx
+++ b/src/pages/MechanicHistory.jsx
@@ -1,14 +1,26 @@
 import { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useParams } from "react-router-dom";
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  getDocs,
+} from "firebase/firestore";
 import { listMechanics } from "../services/mechanicService";
 import { listQuickServices } from "../services/quickServiceService";
+import GenericDataTable from "../components/GenericDataTable";
+import { db } from "../config/firebase";
 
 const MechanicHistory = () => {
   const { id } = useParams();
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [mechanic, setMechanic] = useState(null);
   const [services, setServices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [dateRange, setDateRange] = useState({ start: "", end: "" });
+  const [originFilter, setOriginFilter] = useState("all");
 
   useEffect(() => {
     const theme = localStorage.getItem("theme");
@@ -16,15 +28,111 @@ const MechanicHistory = () => {
       setIsDarkMode(true);
       document.documentElement.classList.add("dark");
     }
-    listMechanics().then((list) => {
-      setMechanic(list.find((m) => m.id === id));
-    });
-    listQuickServices()
-      .then((data) => {
-        setServices(data.filter((s) => s.mecanicoId === id));
-      })
-      .catch(console.error);
+    const loadData = async () => {
+      try {
+        const mechList = await listMechanics();
+        setMechanic(mechList.find((m) => m.id === id));
+
+        const quicks = await listQuickServices();
+        const quickServices = quicks
+          .filter((s) => s.mecanicoId === id)
+          .map((s) => ({
+            id: s.id,
+            data: s.dataCriacao ? new Date(s.dataCriacao) : new Date(),
+            os: "",
+            servico: s.servico,
+            quantidade: parseInt(s.quantidade) || 1,
+            valor: (parseFloat(s.valor) || 0) * (parseInt(s.quantidade) || 1),
+            observacoes: s.observacoes || "",
+            origem: "Avulso",
+          }));
+
+        const ordensRef = collection(db, "ordens");
+        const ordersQuery = query(
+          ordensRef,
+          where("mecanicoId", "==", id),
+          orderBy("dataCriacao", "desc")
+        );
+        const ordersSnap = await getDocs(ordersQuery);
+        const orderServices = [];
+        ordersSnap.forEach((doc) => {
+          const data = doc.data();
+          if (data.status !== "Pronto") return;
+          const orderDate = data.dataAtualizacao
+            ? data.dataAtualizacao.toDate()
+            : data.dataCriacao.toDate();
+          if (data.bicicletas?.length > 0) {
+            data.bicicletas.forEach((bike) => {
+              if (bike.valorServicos) {
+                Object.entries(bike.valorServicos).forEach(([serviceName, valor]) => {
+                  const quantidade = bike.services?.[serviceName] || 1;
+                  orderServices.push({
+                    id: `${doc.id}-${serviceName}`,
+                    data: orderDate,
+                    os: data.codigo || doc.id,
+                    servico: serviceName,
+                    quantidade,
+                    valor: parseFloat(valor) * quantidade,
+                    observacoes: bike.observacoes || "",
+                    origem: "OS",
+                  });
+                });
+              }
+            });
+          }
+        });
+
+        setServices([...quickServices, ...orderServices]);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
   }, [id]);
+
+  const monthlyCounts = services.reduce((acc, s) => {
+    const key = s.data.toLocaleString("pt-BR", { month: "long", year: "numeric" });
+    acc[key] = (acc[key] || 0) + s.quantidade;
+    return acc;
+  }, {});
+
+  const filteredServices = services.filter((s) => {
+    if (originFilter !== "all" && s.origem !== originFilter) return false;
+    if (dateRange.start) {
+      const start = new Date(dateRange.start);
+      start.setHours(0, 0, 0, 0);
+      if (s.data < start) return false;
+    }
+    if (dateRange.end) {
+      const end = new Date(dateRange.end);
+      end.setHours(23, 59, 59, 999);
+      if (s.data > end) return false;
+    }
+    return true;
+  });
+
+  const tableData = filteredServices.map((s) => ({
+    data: s.data.toLocaleDateString("pt-BR"),
+    os: s.os,
+    servico: s.servico,
+    quantidade: s.quantidade,
+    valor: `R$ ${Number(s.valor).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`,
+    origem: s.origem,
+    observacoes: s.observacoes,
+  }));
+
+  const columns = [
+    { name: "data", label: "Data" },
+    { name: "os", label: "OS" },
+    { name: "servico", label: "Serviço" },
+    { name: "quantidade", label: "Qtd" },
+    { name: "valor", label: "Valor" },
+    { name: "origem", label: "Origem", options: { filter: true } },
+    { name: "observacoes", label: "Obs" },
+  ];
 
   return (
     <div className={`min-h-screen ${isDarkMode ? "dark" : ""}`}>
@@ -41,38 +149,55 @@ const MechanicHistory = () => {
           {services.length === 0 ? (
             <p className="text-gray-700 dark:text-gray-300">Nenhum serviço registrado.</p>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-sm">
-                <thead>
-                  <tr className="border-b border-gray-200 dark:border-gray-600">
-                    <th className="py-2 px-2 text-left">Data</th>
-                    <th className="py-2 px-2 text-left">Serviço</th>
-                    <th className="py-2 px-2 text-center">Qtd</th>
-                    <th className="py-2 px-2 text-right">Valor</th>
-                    <th className="py-2 px-2 text-left">Obs</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {services.map((s) => (
-                    <tr
-                      key={s.id}
-                      className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    >
-                      <td className="py-2 px-2">
-                        {s.dataCriacao
-                          ? new Date(s.dataCriacao).toLocaleDateString("pt-BR")
-                          : ""}
-                      </td>
-                      <td className="py-2 px-2">{s.servico}</td>
-                      <td className="py-2 px-2 text-center">{s.quantidade}</td>
-                      <td className="py-2 px-2 text-right">
-                        R$ {Number(s.valor).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
-                      </td>
-                      <td className="py-2 px-2">{s.observacoes || ""}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+            <div>
+              <div className="mb-4 space-y-1">
+                {Object.entries(monthlyCounts).map(([month, count]) => (
+                  <p key={month} className="text-gray-700 dark:text-gray-300">
+                    {month}: {count}
+                  </p>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap gap-4 mb-4">
+                <div>
+                  <label className="block text-sm mb-1">Data início</label>
+                  <input
+                    type="date"
+                    className="border rounded px-2 py-1"
+                    value={dateRange.start}
+                    onChange={(e) => setDateRange({ ...dateRange, start: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm mb-1">Data fim</label>
+                  <input
+                    type="date"
+                    className="border rounded px-2 py-1"
+                    value={dateRange.end}
+                    onChange={(e) => setDateRange({ ...dateRange, end: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm mb-1">Origem</label>
+                  <select
+                    className="border rounded px-2 py-1"
+                    value={originFilter}
+                    onChange={(e) => setOriginFilter(e.target.value)}
+                  >
+                    <option value="all">Todas</option>
+                    <option value="OS">OS</option>
+                    <option value="Avulso">Avulso</option>
+                  </select>
+                </div>
+              </div>
+
+              <GenericDataTable
+                title="Histórico de Serviços"
+                columns={columns}
+                data={tableData}
+                loading={loading}
+                options={{ filter: true, search: true }}
+              />
             </div>
           )}
         </main>

--- a/src/pages/MechanicHistory.jsx
+++ b/src/pages/MechanicHistory.jsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useParams } from "react-router-dom";
 import { listMechanics } from "../services/mechanicService";
+import { listQuickServices } from "../services/quickServiceService";
 
 const MechanicHistory = () => {
   const { id } = useParams();
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [mechanic, setMechanic] = useState(null);
+  const [services, setServices] = useState([]);
 
   useEffect(() => {
     const theme = localStorage.getItem("theme");
@@ -17,6 +19,11 @@ const MechanicHistory = () => {
     listMechanics().then((list) => {
       setMechanic(list.find((m) => m.id === id));
     });
+    listQuickServices()
+      .then((data) => {
+        setServices(data.filter((s) => s.mecanicoId === id));
+      })
+      .catch(console.error);
   }, [id]);
 
   return (
@@ -31,7 +38,43 @@ const MechanicHistory = () => {
           </h1>
         </header>
         <main className="p-4">
-          <p className="text-gray-700 dark:text-gray-300">Histórico não implementado.</p>
+          {services.length === 0 ? (
+            <p className="text-gray-700 dark:text-gray-300">Nenhum serviço registrado.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-600">
+                    <th className="py-2 px-2 text-left">Data</th>
+                    <th className="py-2 px-2 text-left">Serviço</th>
+                    <th className="py-2 px-2 text-center">Qtd</th>
+                    <th className="py-2 px-2 text-right">Valor</th>
+                    <th className="py-2 px-2 text-left">Obs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {services.map((s) => (
+                    <tr
+                      key={s.id}
+                      className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                      <td className="py-2 px-2">
+                        {s.dataCriacao
+                          ? new Date(s.dataCriacao).toLocaleDateString("pt-BR")
+                          : ""}
+                      </td>
+                      <td className="py-2 px-2">{s.servico}</td>
+                      <td className="py-2 px-2 text-center">{s.quantidade}</td>
+                      <td className="py-2 px-2 text-right">
+                        R$ {Number(s.valor).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                      </td>
+                      <td className="py-2 px-2">{s.observacoes || ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </main>
       </div>
     </div>

--- a/src/pages/NewOrder.jsx
+++ b/src/pages/NewOrder.jsx
@@ -855,6 +855,7 @@ function NewOrder() {
         </header>
 
         {/* MAIN */}
+        {!createdOrder ? (
         <main className="container mx-auto px-4 py-8 pb-24">
         {error && (
           <div className="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
@@ -1264,33 +1265,44 @@ function NewOrder() {
             >
               Criar Ordem de Serviço
             </button>
-
-            {/* Se a ordem foi criada, mostramos botões de impressão */}
-            {createdOrder && (
-              <div className="mt-6 space-x-4">
-                <button
-                  onClick={() => generatePDFClient(createdOrder)}
-                  className="bg-purple-600 text-white px-6 py-2 rounded-lg hover:bg-purple-700"
-                >
-                  Imprimir Versão Cliente
-                </button>
-                <button
-                  onClick={() => generatePDFStore(createdOrder)}
-                  className="bg-orange-600 text-white px-6 py-2 rounded-lg hover:bg-orange-700"
-                >
-                  Imprimir Versão Loja
-                </button>
-                <button
-                  onClick={() => generateWorkshopTagsPDF(createdOrder)}
-                  className="bg-green-600 text-white px-6 py-2 rounded-lg hover:bg-green-700"
-                >
-                  Imprimir Etiquetas
-                </button>
-              </div>
-            )}
           </div>
         )}
       </main>
+        ) : (
+      <main className="container mx-auto px-4 py-8 pb-24">
+        <h2 className="text-2xl font-bold mb-4">Ordem criada com sucesso!</h2>
+        <div className="space-y-6">
+          <div className="space-x-4">
+            <button
+              onClick={() => generatePDFClient(createdOrder)}
+              className="bg-purple-600 text-white px-6 py-2 rounded-lg hover:bg-purple-700"
+            >
+              Imprimir Versão Cliente
+            </button>
+            <button
+              onClick={() => generatePDFStore(createdOrder)}
+              className="bg-orange-600 text-white px-6 py-2 rounded-lg hover:bg-orange-700"
+            >
+              Imprimir Versão Loja
+            </button>
+            <button
+              onClick={() => generateWorkshopTagsPDF(createdOrder)}
+              className="bg-green-600 text-white px-6 py-2 rounded-lg hover:bg-green-700"
+            >
+              Imprimir Etiquetas
+            </button>
+          </div>
+          <div>
+            <button
+              onClick={() => window.location.reload()}
+              className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700"
+            >
+              Criar nova ordem
+            </button>
+          </div>
+        </div>
+      </main>
+        )}
       </div>
     </div>
   );

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -239,7 +239,8 @@ const ReportsManagement = () => {
           const endDate = new Date(dateRange.end);
           endDate.setHours(23, 59, 59, 999);
           return (
-            order.status?.toLowerCase() === 'pronto' &&
+            (order.status?.toLowerCase() === 'pronto' ||
+              order.status?.toLowerCase() === 'entregue') &&
             order.data >= startDate &&
             order.data <= endDate
           );

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -191,7 +191,7 @@ const ReportsManagement = () => {
                     totalServicos += quantidade;
                     detailRows.push({
                       data: orderDate,
-                      os: doc.id,
+                      os: data.codigo || doc.id,
                       servico: serviceName,
                       quantidade,
                       valor: servicoTotal,
@@ -212,7 +212,7 @@ const ReportsManagement = () => {
                     totalServicos += quantidade;
                     detailRows.push({
                       data: orderDate,
-                      os: doc.id,
+                      os: data.codigo || doc.id,
                       servico: serviceName,
                       quantidade,
                       valor: servicoTotal,

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -172,13 +172,12 @@ const ReportsManagement = () => {
           let totalValor = 0;
           let totalServicos = 0;
 
-          const orderDate = data.dataAtualizacao
-            ? (typeof data.dataAtualizacao === 'string'
-                ? new Date(data.dataAtualizacao)
-                : data.dataAtualizacao.toDate())
-            : (typeof data.dataCriacao === 'string'
-                ? new Date(data.dataCriacao)
-                : data.dataCriacao.toDate());
+          const getDate = (field) =>
+            field ? (typeof field === 'string' ? new Date(field) : field.toDate()) : null;
+          const orderDate =
+            getDate(data.dataConclusao) ||
+            getDate(data.dataAtualizacao) ||
+            getDate(data.dataCriacao);
 
           if (data.bicicletas?.length > 0) {
             data.bicicletas.forEach((bike) => {

--- a/src/pages/ReportsManagement.jsx
+++ b/src/pages/ReportsManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { ArrowLeft, Download, BarChart3, Calendar, TrendingUp, DollarSign, Package } from "lucide-react";
 import { collection, query, getDocs, where, orderBy } from "firebase/firestore";
 import { db } from "../config/firebase";
@@ -44,6 +44,7 @@ const ReportsManagement = () => {
   const averageTicket = totalServices ? totalRevenue / totalServices : 0;
   const tableColumns = [
     { name: "data", label: "Data" },
+    { name: "os", label: "OS" },
     { name: "servico", label: "Serviço" },
     { name: "mecanico", label: "Mecânico" },
     { name: "origem", label: "Origem" },
@@ -190,6 +191,7 @@ const ReportsManagement = () => {
                     totalServicos += quantidade;
                     detailRows.push({
                       data: orderDate,
+                      os: doc.id,
                       servico: serviceName,
                       quantidade,
                       valor: servicoTotal,
@@ -210,6 +212,7 @@ const ReportsManagement = () => {
                     totalServicos += quantidade;
                     detailRows.push({
                       data: orderDate,
+                      os: doc.id,
                       servico: serviceName,
                       quantidade,
                       valor: servicoTotal,
@@ -259,6 +262,7 @@ const ReportsManagement = () => {
             const valorTotal = (parseFloat(data.valor) || 0) * quantidade;
             detailRows.push({
               data: dataCriacao,
+              os: "",
               servico: data.servico,
               quantidade,
               valor: valorTotal,

--- a/src/pages/WorkshopDashboard.jsx
+++ b/src/pages/WorkshopDashboard.jsx
@@ -31,7 +31,9 @@ import {
   updateOrderPart,
   getOrder,
   getServices,
+  updateOrderMechanic,
 } from "../services/orderService";
+import { listMechanics } from "../services/mechanicService";
 
 // -------- ADAPTAÇÃO: Importação para PDF (sem remover nada do seu código) --------
 import { jsPDF } from "jspdf";
@@ -90,6 +92,7 @@ const WorkshopDashboard = () => {
   const [showServiceModal, setShowServiceModal] = useState(false);
   const [showPartModal, setShowPartModal] = useState(false);
   const [serviceTable, setServiceTable] = useState({});
+  const [mechanics, setMechanics] = useState([]);
 
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme");
@@ -114,13 +117,15 @@ const WorkshopDashboard = () => {
     const initialize = async () => {
       try {
         setLoading(true);
-        const [ordersData, servicesData] = await Promise.all([
+        const [ordersData, servicesData, mechanicsData] = await Promise.all([
           getOrders(),
           getServices(),
+          listMechanics(),
         ]);
 
         setOrders(ordersData);
         setServiceTable(servicesData);
+        setMechanics(mechanicsData);
       } catch (err) {
         console.error("Erro ao inicializar:", err);
         setError("Erro ao carregar dados. Por favor, recarregue a página.");
@@ -187,6 +192,16 @@ const WorkshopDashboard = () => {
     } catch (error) {
       console.error("Erro ao atualizar ordem:", error);
       setError("Erro ao atualizar ordem");
+    }
+  };
+
+  const handleAssignMechanic = async (orderId, mechanicId) => {
+    try {
+      await updateOrderMechanic(orderId, mechanicId);
+      await handleOrderUpdate();
+    } catch (error) {
+      console.error("Erro ao atribuir mecânico:", error);
+      setError("Erro ao atribuir mecânico");
     }
   };
 
@@ -803,6 +818,20 @@ const WorkshopDashboard = () => {
                 Gerar Recibo
               </button>
             )}
+          </div>
+          <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+            <select
+              value={order.mecanicoId || ""}
+              onChange={(e) => handleAssignMechanic(order.id, e.target.value)}
+              className="w-full bg-gray-50 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md px-2 py-1 text-sm"
+            >
+              <option value="">Sem mecânico</option>
+              {mechanics.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.nome}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
       </div>

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -178,10 +178,14 @@ export const updateOrderService = async (orderId, bikeIndex, oldServiceName, upd
 export const updateOrderStatus = async (orderId, newStatus) => {
   try {
     const orderRef = doc(db, 'ordens', orderId);
-    await updateDoc(orderRef, {
+    const updateData = {
       status: newStatus,
       dataAtualizacao: serverTimestamp()
-    });
+    };
+    if (newStatus === 'Pronto') {
+      updateData.dataConclusao = serverTimestamp();
+    }
+    await updateDoc(orderRef, updateData);
     return true;
   } catch (error) {
     console.error('Erro ao atualizar status:', error);

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -178,13 +178,27 @@ export const updateOrderService = async (orderId, bikeIndex, oldServiceName, upd
 export const updateOrderStatus = async (orderId, newStatus) => {
   try {
     const orderRef = doc(db, 'ordens', orderId);
-    await updateDoc(orderRef, { 
+    await updateDoc(orderRef, {
       status: newStatus,
       dataAtualizacao: serverTimestamp()
     });
     return true;
   } catch (error) {
     console.error('Erro ao atualizar status:', error);
+    throw error;
+  }
+};
+
+export const updateOrderMechanic = async (orderId, mechanicId) => {
+  try {
+    const orderRef = doc(db, 'ordens', orderId);
+    await updateDoc(orderRef, {
+      mecanicoId: mechanicId,
+      dataAtualizacao: serverTimestamp()
+    });
+    return true;
+  } catch (error) {
+    console.error('Erro ao atualizar mecânico:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- display OS identifiers in service reports
- implement mechanic history listing quick services per mechanic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 134 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68954a7297e4832e93eb26d2fb3b9453