### PR TITLE
chore(vercel): set version 2 + nodejs18 + SPA rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,11 @@
 {
-    "rewrites": [
-      {
-        "source": "/(.*)",
-        "destination": "/index.html"
-      }
-    ]
-  }
+  "version": 2,
+  "functions": {
+    "api/**/*.{js,ts}": {
+      "runtime": "nodejs18.x"
+    }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Vercel with version 2, Node.js 18 functions, and SPA rewrites

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prop-types & unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6896c172d4dc832e98f08e56c44d8deb