### PR TITLE
feat: migrate images to Cloudinary (unsigned upload + serverless delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A management system for the Sport & Bike bicycle store built with React, Vite an
    ```bash
    npm install
    ```
-2. Create a `.env.local` file with your Firebase configuration:
+2. Create a `.env.local` file with your Firebase configuration and Cloudinary vars:
    ```bash
    VITE_FIREBASE_API_KEY=your_key
    VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
@@ -24,11 +24,25 @@ A management system for the Sport & Bike bicycle store built with React, Vite an
    VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
    VITE_FIREBASE_APP_ID=your_app_id
    VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+   VITE_CLOUDINARY_CLOUD_NAME=your_cloud_name
+   VITE_CLOUDINARY_UPLOAD_PRESET=your_unsigned_preset
+   # optional token used to authorize deletions
+   VITE_ADMIN_API_TOKEN=some_strong_token
    ```
 3. Run the development server:
    ```bash
    npm run dev
    ```
+
+### Serverless environment variables (Vercel)
+
+On Vercel (Production + Preview) define these additional variables:
+```bash
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_API_KEY=xxxxx
+CLOUDINARY_API_SECRET=yyyyy
+ADMIN_API_TOKEN=some_strong_token
+```
 
 ## Building
 

--- a/api/cloudinary-delete.ts
+++ b/api/cloudinary-delete.ts
@@ -1,0 +1,67 @@
+/**
+ * Rota serverless para destruir imagens no Cloudinary (Admin API).
+ *
+ * ENV (server-only | Vercel Settings → Environment Variables):
+ * - CLOUDINARY_CLOUD_NAME
+ * - CLOUDINARY_API_KEY
+ * - CLOUDINARY_API_SECRET
+ * - ADMIN_API_TOKEN   (token para Authorization: Bearer)
+ *
+ * Requisição (POST):
+ *   Headers:
+ *     Authorization: Bearer <ADMIN_API_TOKEN>
+ *     Content-Type: application/json
+ *   Body:
+ *     { "publicId": "folder/my_public_id" }
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { v2 as cloudinary } from "cloudinary";
+
+export const config = { runtime: "nodejs18.x" };
+
+const {
+  CLOUDINARY_CLOUD_NAME,
+  CLOUDINARY_API_KEY,
+  CLOUDINARY_API_SECRET,
+  ADMIN_API_TOKEN,
+} = process.env;
+
+cloudinary.config({
+  cloud_name: CLOUDINARY_CLOUD_NAME,
+  api_key: CLOUDINARY_API_KEY,
+  api_secret: CLOUDINARY_API_SECRET,
+  secure: true,
+});
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ ok: false, error: "Method Not Allowed" });
+  }
+
+  try {
+    if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_API_KEY || !CLOUDINARY_API_SECRET) {
+      return res.status(500).json({ ok: false, error: "Cloudinary envs ausentes" });
+    }
+    if (!ADMIN_API_TOKEN) {
+      return res.status(500).json({ ok: false, error: "ADMIN_API_TOKEN ausente" });
+    }
+
+    const auth = req.headers.authorization || "";
+    const token = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
+    if (token !== ADMIN_API_TOKEN) {
+      return res.status(401).json({ ok: false, error: "Unauthorized" });
+    }
+
+    const { publicId } = req.body || {};
+    if (!publicId || typeof publicId !== "string") {
+      return res.status(400).json({ ok: false, error: "publicId inválido" });
+    }
+
+    const result = await cloudinary.uploader.destroy(publicId, { invalidate: true });
+    return res.status(200).json({ ok: true, result });
+  } catch (e: any) {
+    return res.status(500).json({ ok: false, error: e?.message || "Erro interno" });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.18.0",
         "@mui/material": "^5.18.0",
         "@tanstack/react-query": "^5.62.3",
+        "cloudinary": "^2.7.0",
         "date-fns": "^4.1.0",
         "firebase": "^11.0.2",
         "html2canvas": "^1.4.1",
@@ -3196,6 +3197,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6019,6 +6033,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qrcode.react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.18.0",
     "@tanstack/react-query": "^5.62.3",
+    "cloudinary": "^2.7.0",
     "date-fns": "^4.1.0",
     "firebase": "^11.0.2",
     "html2canvas": "^1.4.1",

--- a/src/components/FeaturedGrid.jsx
+++ b/src/components/FeaturedGrid.jsx
@@ -1,0 +1,60 @@
+/**
+ * FeaturedGrid.jsx
+ * Lê "featured" (visible == true), orderBy(createdAt desc).
+ * Renderiza cards com imageUrlCard || imageUrl, título, descrição e preço (R$).
+ */
+
+import { useEffect, useState } from "react";
+import { collection, onSnapshot, orderBy, query, where } from "firebase/firestore";
+import { db } from "../config/firebase";
+
+function fmtBRL(n) {
+  const v = Number(n || 0);
+  return v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+}
+
+export default function FeaturedGrid() {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    const q = query(
+      collection(db, "featured"),
+      where("visible", "==", true),
+      orderBy("createdAt", "desc")
+    );
+    const unsub = onSnapshot(q, (snap) => {
+      setItems(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsub();
+  }, []);
+
+  return (
+    <section className="max-w-6xl mx-auto p-4">
+      <h2 className="text-xl font-semibold mb-4">Destaques</h2>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items.map((it) => (
+          <article key={it.id} className="border border-neutral-800 rounded-xl overflow-hidden">
+            <div className="aspect-video bg-neutral-900">
+              {(it.imageUrlCard || it.imageUrl) ? (
+                <img
+                  src={it.imageUrlCard || it.imageUrl}
+                  alt={it.title}
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="w-full h-full grid place-items-center text-neutral-500 text-sm">Sem imagem</div>
+              )}
+            </div>
+            <div className="p-3 grid gap-1">
+              <h3 className="font-medium">{it.title}</h3>
+              {it.description && <p className="text-sm text-neutral-300 line-clamp-2">{it.description}</p>}
+              <div className="text-sm">{fmtBRL(it.price)}</div>
+            </div>
+          </article>
+        ))}
+      </div>
+      {items.length === 0 && <div className="text-sm text-neutral-400 mt-3">Nenhum destaque disponível no momento.</div>}
+    </section>
+  );
+}

--- a/src/pages/HomeManagement.jsx
+++ b/src/pages/HomeManagement.jsx
@@ -1,434 +1,376 @@
-"use client"
+/**
+ * HomeManagement.jsx
+ *
+ * - CRUD de "featured" no Firestore.
+ * - Imagem por arquivo (upload Cloudinary unsigned) OU URL colada.
+ * - Salva: title, description, price (number), visible (boolean),
+ *          imageUrl, imageUrlCard, publicId, createdAt, updatedAt.
+ * - Ao editar e trocar imagem: se tinha publicId antigo, deleta via /api/cloudinary-delete.
+ * - Ao remover item: se tiver publicId, deleta via /api/cloudinary-delete e depois apaga o doc.
+ *
+ * ENV (client):
+ * - VITE_CLOUDINARY_CLOUD_NAME
+ * - VITE_CLOUDINARY_UPLOAD_PRESET
+ * - VITE_ADMIN_API_TOKEN (opcional; para Authorization da deleção)
+ *
+ * IMPORTANTE: Remover totalmente o uso de Firebase Storage nesta tela.
+ */
 
-import React, { useEffect, useState } from "react"
-import { useNavigate } from "react-router-dom"
+import { useEffect, useState } from "react";
 import {
-  ArrowLeft,
-  Bike,
-  Plus,
-  Edit,
-  Trash2,
-  Eye,
-  EyeOff,
-  Search,
-} from "lucide-react"
+  collection,
+  addDoc,
+  serverTimestamp,
+  onSnapshot,
+  orderBy,
+  query,
+  updateDoc,
+  deleteDoc,
+  doc,
+} from "firebase/firestore";
+import { db } from "../config/firebase";
 import {
-  getFeaturedProducts,
-  createFeaturedProduct,
-  updateFeaturedProduct,
-  deleteFeaturedProduct,
-  getHomeSettings,
-  updateHomeSettings,
-} from "../services/homeService"
-import { uploadImage } from "../services/uploadImage"
+  uploadImageToCloudinary,
+  optimizeCloudinaryUrl,
+  isCloudinaryUrl,
+  extractPublicIdFromUrl,
+} from "../services/cloudinary";
 
-const normalizeDriveUrl = (url) => {
-  if (!url) return url
-  const file = url.match(/https?:\/\/drive\.google\.com\/file\/d\/([a-zA-Z0-9_-]+)/)
-  if (file) return `https://drive.google.com/uc?export=view&id=${file[1]}`
-  const open = url.match(/https?:\/\/drive\.google\.com\/open\?id=([a-zA-Z0-9_-]+)/)
-  if (open) return `https://drive.google.com/uc?export=view&id=${open[1]}`
-  const uc = url.match(/https?:\/\/drive\.google\.com\/uc\?id=([a-zA-Z0-9_-]+)/)
-  if (uc) return `https://drive.google.com/uc?export=view&id=${uc[1]}`
-  return url
+const ADMIN_API_TOKEN = import.meta.env.VITE_ADMIN_API_TOKEN; // opcional
+
+function fmtBRL(n) {
+  const v = Number(n || 0);
+  return v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 }
 
-const emptyProduct = {
-  name: "",
-  price: "",
-  image: "",
-  category: "",
-  description: "",
-  visible: true,
-}
-
-const ProductModal = ({ isEdit, onClose, onSave, product }) => {
-  const [formData, setFormData] = useState({
-    ...emptyProduct,
-    ...product,
-    visible: product?.visible ?? true,
-  })
-  const [imageFile, setImageFile] = useState(null)
-  const [preview, setPreview] = useState(product?.image || "")
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  const handleChange = (e) => {
-    const { name, value } = e.target
-    setFormData((prev) => ({ ...prev, [name]: value }))
-  }
-
-  const handleFileChange = (e) => {
-    const file = e.target.files?.[0]
-    if (file) {
-      setImageFile(file)
-      setPreview(URL.createObjectURL(file))
-    }
-  }
-
-  const handleUrlChange = (e) => {
-    const value = e.target.value
-    setFormData((prev) => ({ ...prev, image: value }))
-    setPreview(normalizeDriveUrl(value))
-  }
-
-  const handleSubmit = async (e) => {
-    e.preventDefault()
-    if (isSubmitting) return
-    setIsSubmitting(true)
-    try {
-      await onSave({ ...formData, imageFile })
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-lg w-full max-w-md p-6">
-        <h3 className="text-xl font-bold mb-4 text-gray-800 dark:text-white">
-          {isEdit ? "Editar" : "Novo"} Produto
-        </h3>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">Nome</label>
-            <input
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              className="w-full border rounded px-3 py-2"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Preço</label>
-            <input
-              name="price"
-              value={formData.price}
-              onChange={handleChange}
-              className="w-full border rounded px-3 py-2"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Categoria</label>
-            <input
-              name="category"
-              value={formData.category}
-              onChange={handleChange}
-              className="w-full border rounded px-3 py-2"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Descrição</label>
-            <textarea
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              className="w-full border rounded px-3 py-2"
-              rows="3"
-            />
-          </div>
-          <label className="flex items-center space-x-2">
-            <input
-              type="checkbox"
-              name="visible"
-              checked={formData.visible}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, visible: e.target.checked }))
-              }
-              className="w-4 h-4"
-            />
-            <span className="text-sm">Exibir produto</span>
-          </label>
-          <div>
-            <label className="block text-sm font-medium mb-1">Link da Imagem (Google Drive)</label>
-            <input
-              name="image"
-              value={formData.image}
-              onChange={handleUrlChange}
-              className="w-full border rounded px-3 py-2 mb-2"
-              placeholder="https://drive.google.com/..."
-            />
-            <label className="block text-sm font-medium mb-1">Upload da Imagem</label>
-            <input type="file" accept="image/*" onChange={handleFileChange} className="w-full" />
-            {preview && (
-              <img
-                src={preview}
-                alt="Pré-visualização"
-                className="mt-2 w-full h-60 object-cover rounded"
-              />
-            )}
-          </div>
-          <div className="flex justify-end gap-4 mt-4">
-            <button type="button" onClick={onClose} className="px-4 py-2 text-gray-600 dark:text-gray-300">
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className={`px-6 py-2 rounded text-white ${
-                isSubmitting
-                  ? "bg-blue-300 cursor-not-allowed"
-                  : "bg-blue-500 hover:bg-blue-600"
-              }`}
-            >
-              {isSubmitting ? "Salvando..." : "Salvar"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  )
+function parsePrice(input) {
+  if (typeof input === "number") return input;
+  const norm = String(input || "").replace(/\./g, "").replace(",", ".");
+  const num = Number(norm);
+  return Number.isFinite(num) ? num : 0;
 }
 
 export default function HomeManagement() {
-  const navigate = useNavigate()
-  const [isDarkMode, setIsDarkMode] = useState(false)
-  const [products, setProducts] = useState([])
-  const [showFeatured, setShowFeatured] = useState(true)
-  const [loading, setLoading] = useState(true)
-  const [showModal, setShowModal] = useState(false)
-  const [editProduct, setEditProduct] = useState(null)
-  const [searchTerm, setSearchTerm] = useState("")
+  const [items, setItems] = useState([]);
 
-  const loadData = async () => {
-    const [prods, settings] = await Promise.all([getFeaturedProducts(), getHomeSettings()])
-    setProducts(prods)
-    setShowFeatured(settings.showFeaturedProducts ?? true)
-    setLoading(false)
-  }
+  const [editingId, setEditingId] = useState(null);
+  const [title, setTitle] = useState("");
+  const [description, setDesc] = useState("");
+  const [priceInput, setPriceInput] = useState("");
+  const [visible, setVisible] = useState(true);
 
-  useEffect(() => {
-    loadData()
-  }, [])
+  const [imageMode, setImageMode] = useState("file"); // "file" | "url"
+  const [file, setFile] = useState(null);
+  const [urlInput, setUrlInput] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem("theme")
-    if (savedTheme === "dark") {
-      setIsDarkMode(true)
-      document.documentElement.classList.add("dark")
+    const q = query(collection(db, "featured"), orderBy("createdAt", "desc"));
+    const unsub = onSnapshot(q, (snap) => {
+      setItems(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsub();
+  }, []);
+
+  function resetForm() {
+    setEditingId(null);
+    setTitle("");
+    setDesc("");
+    setPriceInput("");
+    setVisible(true);
+    setImageMode("file");
+    setFile(null);
+    setUrlInput("");
+    setErr("");
+  }
+
+  async function callDeleteOnServer(publicId) {
+    if (!publicId) return { ok: true };
+    const res = await fetch("/api/cloudinary-delete", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(ADMIN_API_TOKEN ? { Authorization: `Bearer ${ADMIN_API_TOKEN}` } : {}),
+      },
+      body: JSON.stringify({ publicId }),
+    });
+    if (!res.ok) {
+      const t = await res.text().catch(() => "");
+      throw new Error(`Falha ao deletar no Cloudinary: ${res.status} ${res.statusText} ${t}`);
     }
-  }, [])
+    return res.json();
+  }
 
-  const handleAdd = async (data) => {
-    let imageUrl = data.image ? normalizeDriveUrl(data.image) : ""
-    if (data.imageFile) {
-      imageUrl = await uploadImage(data.imageFile)
+  async function handleSubmit(e) {
+    e?.preventDefault?.();
+    setErr("");
+    setLoading(true);
+    try {
+      const price = parsePrice(priceInput);
+
+      let imageUrl = "";
+      let imageUrlCard = "";
+      let publicId = null;
+
+      if (imageMode === "file") {
+        if (!file) throw new Error("Selecione um arquivo de imagem.");
+        const { secureUrl, publicId: pid } = await uploadImageToCloudinary(file);
+        imageUrl = secureUrl;
+        imageUrlCard = optimizeCloudinaryUrl(secureUrl, 800);
+        publicId = pid;
+      } else {
+        if (!urlInput.trim()) throw new Error("Informe a URL da imagem.");
+        imageUrl = urlInput.trim();
+        if (isCloudinaryUrl(imageUrl)) {
+          imageUrlCard = optimizeCloudinaryUrl(imageUrl, 800);
+          publicId = extractPublicIdFromUrl(imageUrl); // best-effort
+        } else {
+          imageUrlCard = imageUrl; // fallback
+          publicId = null;
+        }
+      }
+
+      const payload = {
+        title: title.trim(),
+        description: description.trim(),
+        price,
+        visible: !!visible,
+        imageUrl,
+        imageUrlCard: imageUrlCard || imageUrl,
+        publicId: publicId || null,
+        updatedAt: serverTimestamp(),
+      };
+
+      if (!editingId) {
+        await addDoc(collection(db, "featured"), { ...payload, createdAt: serverTimestamp() });
+      } else {
+        const current = items.find((it) => it.id === editingId);
+        const changingImage =
+          (imageMode === "file" && file) ||
+          (imageMode === "url" && urlInput.trim() && urlInput.trim() !== current?.imageUrl);
+
+        if (changingImage && current?.publicId) {
+          await callDeleteOnServer(current.publicId);
+        }
+        await updateDoc(doc(db, "featured", editingId), payload);
+      }
+
+      resetForm();
+    } catch (e) {
+      console.error(e);
+      setErr(e?.message || "Erro ao salvar.");
+    } finally {
+      setLoading(false);
     }
-    await createFeaturedProduct({ ...data, image: imageUrl })
-    setShowModal(false)
-    loadData()
   }
 
-  const handleUpdate = async (data) => {
-    let imageUrl = editProduct.image
-    if (data.imageFile) {
-      imageUrl = await uploadImage(data.imageFile)
-    } else if (data.image) {
-      imageUrl = normalizeDriveUrl(data.image)
+  function startEdit(it) {
+    setEditingId(it.id);
+    setTitle(it.title || "");
+    setDesc(it.description || "");
+    setPriceInput(typeof it.price === "number" ? String(it.price).replace(".", ",") : (it.price ?? ""));
+    setVisible(!!it.visible);
+    setImageMode("url");
+    setUrlInput(it.imageUrl || "");
+    setFile(null);
+    setErr("");
+  }
+
+  async function handleDelete(it) {
+    if (!confirm(`Remover "${it.title}"?`)) return;
+    setLoading(true);
+    setErr("");
+    try {
+      if (it.publicId) await callDeleteOnServer(it.publicId);
+      await deleteDoc(doc(db, "featured", it.id));
+    } catch (e) {
+      console.error(e);
+      setErr(e?.message || "Erro ao remover.");
+    } finally {
+      setLoading(false);
     }
-    await updateFeaturedProduct(editProduct.id, { ...data, image: imageUrl })
-    setEditProduct(null)
-    setShowModal(false)
-    loadData()
   }
 
-  const handleDelete = async (id) => {
-    if (window.confirm("Excluir produto?")) {
-      await deleteFeaturedProduct(id)
-      loadData()
+  async function toggleVisibility(it) {
+    try {
+      await updateDoc(doc(db, "featured", it.id), {
+        visible: !it.visible,
+        updatedAt: serverTimestamp(),
+      });
+    } catch (e) {
+      console.error(e);
+      setErr(e?.message || "Erro ao alternar visibilidade.");
     }
   }
 
-  const handleToggleProductVisibility = async (id, current) => {
-    const newValue = !current
-    setProducts((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, visible: newValue } : p))
-    )
-    await updateFeaturedProduct(id, { visible: newValue })
-  }
-
-  const toggleVisibility = async () => {
-    const newValue = !showFeatured
-    setShowFeatured(newValue)
-    await updateHomeSettings({ showFeaturedProducts: newValue })
-  }
-
-  const filteredProducts = products.filter(
-    (p) =>
-      p.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      p.category.toLowerCase().includes(searchTerm.toLowerCase())
-  )
+  // (Opcional) backfill publicId quando a URL for Cloudinary mas o doc não tiver publicId salvo
+  useEffect(() => {
+    (async () => {
+      const ops = items
+        .filter((it) => !it.publicId && it.imageUrl && isCloudinaryUrl(it.imageUrl))
+        .map(async (it) => {
+          const pid = extractPublicIdFromUrl(it.imageUrl);
+          if (!pid) return;
+          try {
+            await updateDoc(doc(db, "featured", it.id), { publicId: pid, updatedAt: serverTimestamp() });
+          } catch {
+            // ignore
+          }
+        });
+      await Promise.allSettled(ops);
+    })();
+  }, [items]);
 
   return (
-    <div className={`min-h-screen transition-colors duration-300 ${isDarkMode ? "dark" : ""}`}>
-      <div className="bg-gradient-to-br from-gray-50 via-amber-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 min-h-screen">
-        <header className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-white/20 dark:border-gray-700/20 sticky top-0 z-50">
-          <div className="container mx-auto px-4 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-4">
-                <button
-                  onClick={() => navigate("/admin")}
-                  className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
-                >
-                  <ArrowLeft className="w-5 h-5" />
-                </button>
-                <div className="flex items-center space-x-3">
-                  <div className="bg-gradient-to-r from-amber-400 to-amber-600 p-2 rounded-full">
-                    <Bike className="w-6 h-6 text-white" />
-                  </div>
-                  <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Gerenciar Home</h1>
-                </div>
-              </div>
-              <button
-                onClick={() => setShowModal(true)}
-                className="bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white px-6 py-2 rounded-full transition-all transform hover:scale-105 shadow-lg inline-flex items-center space-x-2"
-              >
-                <Plus className="w-5 h-5" />
-                <span>Novo Produto</span>
-              </button>
-            </div>
+    <div className="p-4 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Gerenciar Destaques (Home)</h1>
+
+      <form onSubmit={handleSubmit} className="grid gap-4 p-4 rounded-xl border border-neutral-800">
+        {err && <div className="text-red-500 text-sm">{err}</div>}
+
+        <div className="grid gap-2">
+          <label className="text-sm font-medium">Título</label>
+          <input
+            className="border rounded-lg px-3 py-2 bg-neutral-900 border-neutral-700"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Ex.: Revisão Completa"
+            required
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label className="text-sm font-medium">Descrição</label>
+          <textarea
+            className="border rounded-lg px-3 py-2 bg-neutral-900 border-neutral-700 min-h-[90px]"
+            value={description}
+            onChange={(e) => setDesc(e.target.value)}
+            placeholder="Detalhes do serviço/produto"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label className="text-sm font-medium">Preço</label>
+          <input
+            className="border rounded-lg px-3 py-2 bg-neutral-900 border-neutral-700"
+            value={priceInput}
+            onChange={(e) => setPriceInput(e.target.value)}
+            placeholder="Ex.: 120,50"
+            inputMode="decimal"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label className="text-sm font-medium">Imagem</label>
+
+          <div className="flex gap-3 items-center">
+            <button
+              type="button"
+              onClick={() => setImageMode("file")}
+              className={`px-3 py-1 rounded-lg border ${imageMode === "file" ? "border-blue-500" : "border-neutral-700"}`}
+            >
+              Arquivo
+            </button>
+            <button
+              type="button"
+              onClick={() => setImageMode("url")}
+              className={`px-3 py-1 rounded-lg border ${imageMode === "url" ? "border-blue-500" : "border-neutral-700"}`}
+            >
+              URL
+            </button>
           </div>
-        </header>
-        <main className="container mx-auto px-4 py-8">
-          <div className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl p-6 shadow-xl mb-8">
-            <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-              <div className="flex items-center space-x-4">
-                <label className="flex items-center space-x-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={showFeatured}
-                    onChange={toggleVisibility}
-                    className="w-5 h-5 text-amber-500 rounded focus:ring-amber-500"
-                  />
-                  <span className="text-gray-800 dark:text-white font-medium">Exibir seção de produtos em destaque</span>
-                </label>
-              </div>
-              <div className="flex items-center space-x-4">
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                  <input
-                    type="text"
-                    placeholder="Buscar produtos..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 pr-4 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          {loading ? (
-            <div className="text-center text-gray-600 dark:text-gray-300">Carregando...</div>
+
+          {imageMode === "file" ? (
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+              className="border rounded-lg px-3 py-2 bg-neutral-900 border-neutral-700"
+            />
           ) : (
-            <>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {filteredProducts.map((product) => (
-                  <div
-                    key={product.id}
-                    className="group bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-white/20 dark:border-gray-700/20 rounded-2xl overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2"
-                  >
-                    <div className="relative">
-                      <img
-                        src={product.image}
-                        alt={product.name}
-                        className="w-full h-60 object-cover"
-                        loading="lazy"
-                      />
-                      <div className="absolute top-4 right-4">
-                        <button
-                          onClick={() =>
-                            handleToggleProductVisibility(
-                              product.id,
-                              product.visible !== false
-                            )
-                          }
-                          className={`p-2 rounded-full transition-colors ${
-                            product.visible !== false
-                              ? "bg-amber-500 text-white"
-                              : "bg-white/80 text-gray-600 hover:bg-amber-500 hover:text-white"
-                          }`}
-                          title={
-                            product.visible !== false
-                              ? "Ocultar produto"
-                              : "Exibir produto"
-                          }
-                        >
-                          {product.visible !== false ? (
-                            <Eye className="w-4 h-4" />
-                          ) : (
-                            <EyeOff className="w-4 h-4" />
-                          )}
-                        </button>
-                      </div>
-                      {product.visible === false && (
-                        <div className="absolute top-4 left-4">
-                          <span className="bg-gray-500 text-white px-2 py-1 rounded-full text-xs font-medium">
-                            Oculto
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                    <div className="p-6">
-                      <div className="mb-4">
-                        <span className="text-sm text-amber-600 dark:text-amber-400 font-medium">{product.category}</span>
-                        <h3 className="text-xl font-bold text-gray-800 dark:text-white mt-1">{product.name}</h3>
-                        <p className="text-2xl font-bold text-amber-600 dark:text-amber-400 mt-2">{product.price}</p>
-                        {product.description && (
-                          <p className="text-gray-600 dark:text-gray-300 text-sm mt-2 whitespace-pre-line">
-                            {product.description}
-                          </p>
-                        )}
-                      </div>
-                      <div className="flex items-center justify-between">
-                        <div className="flex space-x-2">
-                          <button
-                            onClick={() => {
-                              setEditProduct(product)
-                              setShowModal(true)
-                            }}
-                            className="p-2 bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-lg hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
-                            title="Editar produto"
-                          >
-                            <Edit className="w-4 h-4" />
-                          </button>
-                          <button
-                            onClick={() => handleDelete(product.id)}
-                            className="p-2 bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
-                            title="Excluir produto"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </div>
-                        <div className="text-sm text-gray-500 dark:text-gray-400">ID: {product.id}</div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              {filteredProducts.length === 0 && (
-                <div className="text-center py-12">
-                  <Bike className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-                  <h3 className="text-xl font-semibold text-gray-600 dark:text-gray-400 mb-2">Nenhum produto encontrado</h3>
-                  <p className="text-gray-500 dark:text-gray-500">Tente ajustar os filtros ou adicione novos produtos</p>
-                </div>
-              )}
-            </>
+            <input
+              type="url"
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              placeholder="https://exemplo.com/imagem.jpg"
+              className="border rounded-lg px-3 py-2 bg-neutral-900 border-neutral-700"
+            />
           )}
-        </main>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input id="visible" type="checkbox" checked={visible} onChange={(e) => setVisible(e.target.checked)} />
+          <label htmlFor="visible" className="text-sm">Visível na Home</label>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={loading}
+            className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+          >
+            {editingId ? (loading ? "Salvando..." : "Salvar alterações") : (loading ? "Criando..." : "Criar destaque")}
+          </button>
+          {editingId && (
+            <button type="button" onClick={resetForm} className="px-4 py-2 rounded-lg border border-neutral-700">
+              Cancelar
+            </button>
+          )}
+        </div>
+      </form>
+
+      <div className="mt-8">
+        <h2 className="text-xl font-semibold mb-3">Itens</h2>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {items.map((it) => (
+            <div key={it.id} className="border border-neutral-800 rounded-xl overflow-hidden">
+              <div className="aspect-video bg-neutral-900">
+                {(it.imageUrlCard || it.imageUrl) ? (
+                  <img
+                    src={it.imageUrlCard || it.imageUrl}
+                    alt={it.title}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full h-full grid place-items-center text-neutral-500 text-sm">Sem imagem</div>
+                )}
+              </div>
+              <div className="p-3 grid gap-2">
+                <div className="font-medium">{it.title}</div>
+                <div className="text-sm text-neutral-300 line-clamp-2">{it.description}</div>
+                <div className="text-sm">{fmtBRL(it.price)}</div>
+
+                <div className="flex gap-2 pt-1">
+                  <button className="px-3 py-1 rounded-lg border border-neutral-700" onClick={() => startEdit(it)}>
+                    Editar
+                  </button>
+                  <button className="px-3 py-1 rounded-lg border border-neutral-700" onClick={() => toggleVisibility(it)}>
+                    {it.visible ? "Ocultar" : "Exibir"}
+                  </button>
+                  <button
+                    className="px-3 py-1 rounded-lg border border-red-800 text-red-300"
+                    onClick={() => handleDelete(it)}
+                  >
+                    Remover
+                  </button>
+                </div>
+
+                <div className="text-[11px] text-neutral-500">
+                  {it.publicId ? `Cloudinary ID: ${it.publicId}` : "Sem publicId"}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {items.length === 0 && (
+          <div className="text-sm text-neutral-400 mt-4">Nenhum item encontrado.</div>
+        )}
       </div>
-      {showModal && (
-        <ProductModal
-          isEdit={!!editProduct}
-          product={editProduct || emptyProduct}
-          onClose={() => {
-            setShowModal(false)
-            setEditProduct(null)
-          }}
-          onSave={editProduct ? handleUpdate : handleAdd}
-        />
-      )}
     </div>
-  )
+  );
 }

--- a/src/services/cloudinary.ts
+++ b/src/services/cloudinary.ts
@@ -1,0 +1,104 @@
+/**
+ * Cloudinary service (client-side)
+ *
+ * ENV (client):
+ * - VITE_CLOUDINARY_CLOUD_NAME
+ * - VITE_CLOUDINARY_UPLOAD_PRESET  (unsigned preset)
+ *
+ * Upload é UNSIGNED: sem secret no front.
+ */
+
+const CLOUD_NAME = import.meta.env.VITE_CLOUDINARY_CLOUD_NAME as string | undefined;
+const UPLOAD_PRESET = import.meta.env.VITE_CLOUDINARY_UPLOAD_PRESET as string | undefined;
+
+function ensureEnv() {
+  if (!CLOUD_NAME || !UPLOAD_PRESET) {
+    throw new Error(
+      "[Cloudinary] Defina VITE_CLOUDINARY_CLOUD_NAME e VITE_CLOUDINARY_UPLOAD_PRESET nas envs."
+    );
+  }
+}
+
+export type UploadResult = {
+  secureUrl: string;
+  publicId: string;
+};
+
+export async function uploadImageToCloudinary(file: File): Promise<UploadResult> {
+  ensureEnv();
+
+  const url = `https://api.cloudinary.com/v1_1/${CLOUD_NAME}/image/upload`;
+  const form = new FormData();
+  form.append("file", file);
+  form.append("upload_preset", UPLOAD_PRESET!);
+
+  const res = await fetch(url, { method: "POST", body: form });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`[Cloudinary] Falha no upload: ${res.status} ${res.statusText} ${txt}`);
+  }
+
+  const json = await res.json();
+  if (!json?.secure_url || !json?.public_id) {
+    throw new Error("[Cloudinary] Resposta inválida (secure_url/public_id ausentes).");
+  }
+
+  return { secureUrl: json.secure_url as string, publicId: json.public_id as string };
+}
+
+/** Injeta f_auto,q_auto,w_{width} após /upload/ em URLs Cloudinary */
+export function optimizeCloudinaryUrl(secureUrl: string, width = 800): string {
+  try {
+    const u = new URL(secureUrl);
+    if (!u.hostname.includes("res.cloudinary.com")) return secureUrl;
+
+    const marker = "/upload/";
+    const i = u.pathname.indexOf(marker);
+    if (i === -1) return secureUrl;
+
+    const before = u.pathname.slice(0, i + marker.length);
+    const after = u.pathname.slice(i + marker.length);
+
+    if (after.startsWith("f_auto") || after.startsWith("q_auto") || after.startsWith("w_")) {
+      return secureUrl; // já possui transformações
+    }
+
+    u.pathname = `${before}f_auto,q_auto,w_${width}/${after}`;
+    return u.toString();
+  } catch {
+    return secureUrl;
+  }
+}
+
+export function isCloudinaryUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.includes("res.cloudinary.com");
+  } catch {
+    return false;
+  }
+}
+
+/** Tenta extrair public_id de URL Cloudinary: /image/upload/.../folder/my_id.jpg → folder/my_id */
+export function extractPublicIdFromUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (!u.hostname.includes("res.cloudinary.com")) return null;
+
+    const parts = u.pathname.split("/").filter(Boolean);
+    const idxUpload = parts.findIndex((p) => p === "upload");
+    if (idxUpload === -1) return null;
+
+    const tail = parts.slice(idxUpload + 1);
+    const cleaned = tail.filter((seg) => !/^v\d+$/i.test(seg) && !/^[a-z_]/i.test(seg));
+    if (cleaned.length === 0) return null;
+
+    const last = cleaned[cleaned.length - 1].replace(/\.[a-z0-9]+$/i, "");
+    if (cleaned.length > 1) {
+      const folder = cleaned.slice(0, -1).join("/");
+      return `${folder}/${last}`;
+    }
+    return last;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add client-side Cloudinary service for unsigned uploads and URL helpers
- introduce serverless `/api/cloudinary-delete` with bearer token auth
- migrate HomeManagement page to Cloudinary and store publicId/imageUrlCard
- show optimized images in public FeaturedGrid
- document required Cloudinary environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 132 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6896ccea143c832e80657b234e65d8f7