### PR TITLE
feat: add Vercel Speed Insights integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^5.18.0",
         "@tanstack/react-query": "^5.62.3",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/speed-insights": "^1.2.0",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.1",
@@ -2575,6 +2576,41 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mui/material": "^5.18.0",
     "@tanstack/react-query": "^5.62.3",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,14 +2,14 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./routes";
 import { AuthProvider } from "./contexts/AuthContext";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/react";
 
-function App() {
+export default function App() {
   return (
     <AuthProvider>
       <RouterProvider router={router} />
       <Analytics />
+      <SpeedInsights />
     </AuthProvider>
   );
 }
-
-export default App;


### PR DESCRIPTION
## Summary
- add @vercel/speed-insights package
- include SpeedInsights component in App root

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prop-types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689918e2c6cc832e97f00924efd59186