### PR TITLE
feat: add smart admin dashboard

### DIFF
--- a/src/components/dashboard/CardDark.jsx
+++ b/src/components/dashboard/CardDark.jsx
@@ -1,0 +1,14 @@
+import PropTypes from "prop-types";
+
+export default function CardDark({ children, className = "" }) {
+  return (
+    <div className={`rounded-xl2 shadow-soft border border-white/10 bg-[#121212] text-white ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+CardDark.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};

--- a/src/components/dashboard/MetricCard.jsx
+++ b/src/components/dashboard/MetricCard.jsx
@@ -1,0 +1,29 @@
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import PropTypes from "prop-types";
+
+export default function MetricCard({ title, value, hint, trend }) {
+  const up = trend && trend.startsWith("+");
+  const Icon = up ? ArrowUpRight : ArrowDownRight;
+  const trendCls = up ? "text-emerald-500 bg-emerald-500/10" : "text-red-500 bg-red-500/10";
+  return (
+    <div className="rounded-xl2 bg-white shadow-soft border border-black/10 p-5">
+      <div className="text-sm text-gray-500">{title}</div>
+      <div className="mt-2 flex items-end justify-between">
+        <div className="text-3xl font-semibold">{value}</div>
+        {trend && (
+          <span className={`ml-2 inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs ${trendCls}`}>
+            <Icon size={14} />
+            {trend} {hint || "vs período"}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+MetricCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  hint: PropTypes.string,
+  trend: PropTypes.string,
+};

--- a/src/components/dashboard/charts/BarTop.jsx
+++ b/src/components/dashboard/charts/BarTop.jsx
@@ -1,0 +1,23 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import PropTypes from "prop-types";
+
+export default function BarTop({ data, dataKey = "total" }) {
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis dataKey="name" axisLine={false} tickLine={false} />
+          <YAxis hide />
+          <Tooltip />
+          <Bar dataKey={dataKey} fill="#FFD600" radius={[6,6,0,0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+BarTop.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  dataKey: PropTypes.string,
+};

--- a/src/components/dashboard/charts/DonutMix.jsx
+++ b/src/components/dashboard/charts/DonutMix.jsx
@@ -1,0 +1,23 @@
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import PropTypes from "prop-types";
+
+const COLORS = ["#FFD600", "#9CA3AF"];
+
+export default function DonutMix({ data }) {
+  return (
+    <div className="h-56 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Tooltip />
+          <Pie data={data} dataKey="value" nameKey="name" innerRadius={60} outerRadius={80} paddingAngle={4} stroke="none">
+            {data.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+DonutMix.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/src/components/dashboard/charts/SparkLine.jsx
+++ b/src/components/dashboard/charts/SparkLine.jsx
@@ -1,0 +1,21 @@
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import PropTypes from "prop-types";
+
+export default function SparkLine({ data }) {
+  return (
+    <div className="h-36 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="name" tickLine={false} axisLine={false} />
+          <YAxis hide />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#FFD600" strokeWidth={3} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+SparkLine.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,7 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+:root { --bg-dark:#0B0B0B; --card-dark:#121212; }
+* { scrollbar-width: thin; scrollbar-color: #FFD600 transparent; }
+*::-webkit-scrollbar{ width:8px; height:8px; }
+*::-webkit-scrollbar-thumb{ border-radius:9999px; background:#FFD60066; }

--- a/src/pages/AdminSmartDashboard.jsx
+++ b/src/pages/AdminSmartDashboard.jsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Bell, Search } from "lucide-react";
+
+import { getDashboardOverview } from "@/services/smartDashboardService";
+import MetricCard from "@/components/dashboard/MetricCard";
+import CardDark from "@/components/dashboard/CardDark";
+import SparkLine from "@/components/dashboard/charts/SparkLine";
+import DonutMix from "@/components/dashboard/charts/DonutMix";
+import BarTop from "@/components/dashboard/charts/BarTop";
+
+export default function AdminSmartDashboard() {
+  const [isDark] = useState(true); // fixa dark no dashboard
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState("7d");
+  const [data, setData] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    document.documentElement.classList.add("dark");
+    load();
+    async function load() {
+      setLoading(true);
+      const res = await getDashboardOverview(period);
+      setData(res);
+      setLoading(false);
+    }
+  }, [period]);
+
+  const kpis = useMemo(() => {
+    if (!data) return [];
+    return [
+      { title: "Ordens no período", value: data.kpis.orders },
+      { title: "Serviços avulsos", value: data.kpis.avulsos },
+      { title: "Faturamento", value: data.kpis.revenue.toLocaleString("pt-BR", { style: "currency", currency: "BRL" }) },
+      { title: "Ticket médio", value: data.kpis.avgTicket.toLocaleString("pt-BR", { style: "currency", currency: "BRL" }) },
+    ];
+  }, [data]);
+
+  return (
+    <div className={`min-h-screen ${isDark ? "bg-[#0B0B0B] text-white" : "bg-gray-50"}`}>
+      {/* Topbar simples */}
+      <header className="h-16 w-full sticky top-0 z-40 bg-[rgba(10,10,10,.85)] backdrop-blur border-b border-white/10">
+        <div className="mx-auto flex h-full max-w-7xl items-center justify-between px-4">
+          <div className="flex items-center gap-3">
+            <div className="h-8 w-8 rounded-md bg-[#FFD600]" />
+            <div className="font-semibold">Sport Bike • Admin</div>
+            <select
+              value={period}
+              onChange={(e)=>setPeriod(e.target.value)}
+              className="ml-4 rounded-md bg-[#121212] border border-white/10 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-[#FFD600]"
+            >
+              <option value="7d">Últimos 7 dias</option>
+              <option value="30d">Últimos 30 dias</option>
+              <option value="today">Hoje</option>
+            </select>
+          </div>
+
+          <div className="hidden md:flex items-center gap-4">
+            <div className="relative w-72">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+              <input
+                placeholder="Buscar"
+                className="w-full rounded-full border border-white/10 bg-[#121212] pl-9 pr-3 py-2 text-sm focus:ring-2 focus:ring-[#FFD600] outline-none"
+              />
+            </div>
+            <button className="relative rounded-full p-2 hover:bg-white/5" aria-label="Notificações">
+              <Bell size={18} />
+              <span className="absolute -right-0.5 -top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-[#FFD600] text-[10px] text-black">1</span>
+            </button>
+            <img src="https://i.pravatar.cc/48?img=5" className="h-8 w-8 rounded-full" alt="avatar" />
+          </div>
+        </div>
+      </header>
+
+      {/* Conteúdo */}
+      <div className="mx-auto max-w-7xl p-4 md:p-6">
+        {/* Banner */}
+        <CardDark className="overflow-hidden">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 p-6">
+            <div className="md:col-span-2">
+              <div className="text-sm text-white/80">Parabéns</div>
+              <h2 className="mt-1 text-2xl md:text-3xl font-semibold">Equipe Sport Bike!</h2>
+              <p className="mt-2 text-white/70 max-w-xl">
+                Este é o painel inteligente: estatísticas em tempo real, ranking de mecânicos, serviços mais vendidos e tendência de faturamento.
+              </p>
+              <button
+                className="mt-4 rounded-lg bg-[#FFD600] px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90"
+                onClick={() => navigate("/admin/orders")}
+              >
+                Gerenciar Ordens
+              </button>
+            </div>
+            <div className="flex items-center justify-center">
+              <div className="h-28 w-28 rounded-full bg-[#FFD600] opacity-20" />
+            </div>
+          </div>
+        </CardDark>
+
+        {/* KPIs */}
+        <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {kpis.map((k) => <MetricCard key={k.title} title={k.title} value={k.value} />)}
+        </div>
+
+        {/* Gráficos principais */}
+        <div className="mt-6 grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <CardDark className="p-5 xl:col-span-2">
+            <div className="mb-3 text-sm text-white/70">Tendência (R$) — {period}</div>
+            {!loading && data && <SparkLine data={data.trend} />}
+          </CardDark>
+
+          <CardDark className="p-5">
+            <div className="mb-3 text-sm text-white/70">Mix de receita</div>
+            {!loading && data && <DonutMix data={data.mix} />}
+          </CardDark>
+        </div>
+
+        {/* Tabelas e rankings */}
+        <div className="mt-6 grid grid-cols-1 xl:grid-cols-2 gap-6">
+          <CardDark className="p-5">
+            <div className="mb-3 text-sm text-white/70">Top serviços por faturamento</div>
+            {!loading && data && <BarTop data={data.topServices} dataKey="total" />}
+          </CardDark>
+
+          <CardDark className="p-5">
+            <div className="mb-3 text-sm text-white/70">Ranking de mecânicos</div>
+            {!loading && data && <BarTop data={data.topMechanics.map(m=>({ name: m.id, total: m.total }))} dataKey="total" />}
+          </CardDark>
+        </div>
+
+        {/* Status das ordens */}
+        {data && (
+          <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-6">
+            {Object.entries(data.statusCount).map(([k, v]) => (
+              <div key={k} className="rounded-xl2 bg-white/5 border border-white/10 p-4">
+                <div className="text-sm text-white/70">{k}</div>
+                <div className="text-2xl font-semibold mt-1">{v}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -2,7 +2,7 @@ import { createBrowserRouter } from "react-router-dom";
 import Home from "../pages/Home";
 import ConsultaOS from "../pages/ConsultaOS";
 import AdminLogin from "../pages/AdminLogin";
-import Admin from "../pages/Admin";
+import AdminSmartDashboard from "../pages/AdminSmartDashboard";
 import WorkshopDashboard from "../pages/WorkshopDashboard";
 import CustomerList from "../pages/CustomerList";
 import ServicesManagement from "../pages/ServicesManagement";
@@ -42,7 +42,7 @@ export const router = createBrowserRouter([
     path: "/admin",
     element: (
       <PrivateRoute>
-        <Admin />
+        <AdminSmartDashboard />
       </PrivateRoute>
     ),
   },

--- a/src/services/smartDashboardService.js
+++ b/src/services/smartDashboardService.js
@@ -1,0 +1,213 @@
+import {
+  collection, getDocs, query, orderBy
+} from "firebase/firestore";
+import { db } from "../config/firebase";
+
+// Normaliza Firestore Timestamp/string/number para Date
+export function toDate(v) {
+  if (!v) return null;
+  if (v?.toDate) return v.toDate();               // Timestamp
+  if (typeof v === "string") {
+    // tenta ISO
+    const d = new Date(v);
+    return isNaN(d) ? null : d;
+  }
+  if (typeof v === "number") return new Date(v);
+  return null;
+}
+
+// Helpers de período
+export function startOfDay(d = new Date()) {
+  const x = new Date(d); x.setHours(0,0,0,0); return x;
+}
+export function endOfDay(d = new Date()) {
+  const x = new Date(d); x.setHours(23,59,59,999); return x;
+}
+export function daysAgo(n) {
+  const x = new Date(); x.setDate(x.getDate() - n); return x;
+}
+
+// --------- Coleta dados brutos por período ----------
+async function getOSInRange(start, end) {
+  // buscamos por dataCriacao e (fallback) dataConclusao, depois filtramos em memória
+  const base = collection(db, "ordens");
+  const q = query(base, orderBy("dataCriacao", "desc"));
+  const snap = await getDocs(q);
+  return snap.docs
+    .map(d => ({ id: d.id, ...d.data() }))
+    .filter(o => {
+      const d1 = toDate(o.dataCriacao) || toDate(o.dataConclusao) || toDate(o.data) || null;
+      return d1 && d1 >= start && d1 <= end;
+    });
+}
+
+async function getAvulsosInRange(start, end) {
+  // Alguns docs têm "data" (Timestamp) e outros "dataCriacao" string/iso
+  const base = collection(db, "servicosAvulsos");
+  const q = query(base, orderBy("data", "desc"));
+  const snap = await getDocs(q);
+  return snap.docs
+    .map(d => ({ id: d.id, ...d.data() }))
+    .filter(a => {
+      const d1 = toDate(a.data) || toDate(a.dataCriacao) || null;
+      return d1 && d1 >= start && d1 <= end;
+    });
+}
+
+async function getReceiptsInRange(start, end) {
+  const base = collection(db, "recibos");
+  // muitos recibos têm createdAt servidor/cliente; fazemos filtro em memória
+  const q = query(base, orderBy("createdAt", "desc"));
+  const snap = await getDocs(q);
+  return snap.docs
+    .map(d => ({ id: d.id, ...d.data() }))
+    .filter(r => {
+      const d1 = toDate(r.createdAt) || toDate(r.data) || null;
+      return d1 && d1 >= start && d1 <= end;
+    });
+}
+
+// --------- Agregações ----------
+export async function getDashboardOverview(period = "7d") {
+  // period: "7d" | "30d" | "today"
+  const now = new Date();
+  let start;
+  if (period === "today") start = startOfDay(now);
+  else if (period === "30d") start = daysAgo(30);
+  else start = daysAgo(7);
+  const end = endOfDay(now);
+
+  const [os, avulsos, recibos] = await Promise.all([
+    getOSInRange(start, end),
+    getAvulsosInRange(start, end),
+    getReceiptsInRange(start, end),
+  ]);
+
+  // Status
+  const statusCount = { Pendente: 0, "Em Andamento": 0, Pronto: 0, Outros: 0 };
+  os.forEach(o => {
+    const s = o.status || "Outros";
+    statusCount[s] = (statusCount[s] || 0) + 1;
+  });
+
+  // Valores (OS: somamos serviços + peças; Avulsos: valor * quantidade; Recibos: total)
+  const currency = (n) => Number(n || 0);
+
+  function sumFromOS(order) {
+    let total = 0;
+    // diferentes formas usadas no projeto:
+    if (Array.isArray(order.bicicletas)) {
+      order.bicicletas.forEach(b => {
+        // serviços
+        if (Array.isArray(b.servicosInclusos)) {
+          b.servicosInclusos.forEach(s => {
+            const q = Number(s.quantidade || b.services?.[s.nome] || 1);
+            const v = Number(s.valorFinal ?? s.valor ?? 0);
+            total += q * v;
+          });
+        }
+        if (b.serviceValues) {
+          Object.entries(b.serviceValues).forEach(([, s]) => {
+            total += Number(s.quantidade || 1) * Number(s.valorFinal ?? s.valor ?? 0);
+          });
+        }
+        if (b.valorServicos) {
+          Object.entries(b.valorServicos).forEach(([, v]) => total += Number(v || 0));
+        }
+        // peças
+        (b.pecas || []).forEach(p => {
+          total += Number(p.quantidade || 1) * Number(p.valor || 0);
+        });
+      });
+    }
+    return total;
+  }
+
+  const revenueOS = os.reduce((acc, o) => acc + sumFromOS(o), 0);
+
+  const revenueAvulso = avulsos.reduce((acc, a) => {
+    const qty = Number(a.quantidade || 1);
+    const val = Number(a.valor || a.valorFinal || 0);
+    return acc + qty * val;
+  }, 0);
+
+  const revenueReceipts = recibos.reduce((acc, r) => acc + currency(r.total || r.valor || 0), 0);
+
+  // Preferência: faturamento real via recibos; fallback OS+Avulsos se recibo não existir
+  const totalRevenue = revenueReceipts > 0 ? revenueReceipts : (revenueOS + revenueAvulso);
+
+  // Ticket médio (base OS + avulsos)
+  const totalItens = os.length + avulsos.length;
+  const avgTicket = totalItens ? totalRevenue / totalItens : 0;
+
+  // Série semanal para gráfico de tendência (últimos 7 dias)
+  const trendDays = Array.from({ length: 7 }).map((_, i) => {
+    const d = daysAgo(6 - i);
+    const k = d.toISOString().slice(0,10);
+    return { key: k, label: k.slice(5), value: 0 };
+  });
+  function addValueByDate(list, getVal) {
+    list.forEach(item => {
+      const d = toDate(item.dataCriacao || item.data || item.createdAt || item.dataConclusao);
+      if (!d) return;
+      const key = d.toISOString().slice(0,10);
+      const t = trendDays.find(x => x.key === key);
+      if (t) t.value += getVal(item);
+    });
+  }
+  addValueByDate(os, (o) => sumFromOS(o));
+  addValueByDate(avulsos, (a) => Number(a.quantidade || 1) * Number(a.valor || a.valorFinal || 0));
+  if (revenueReceipts > 0) addValueByDate(recibos, (r) => Number(r.total || r.valor || 0));
+
+  // Top serviços (contagem e valor) – olhando OS + Avulsos
+  const serviceMap = new Map();
+  function addService(nome, q, v) {
+    const cur = serviceMap.get(nome) || { name: nome, qty: 0, total: 0 };
+    cur.qty += q; cur.total += q * v; serviceMap.set(nome, cur);
+  }
+  os.forEach(o => {
+    (o.bicicletas || []).forEach(b => {
+      if (Array.isArray(b.servicosInclusos)) {
+        b.servicosInclusos.forEach(s => addService(s.nome || s.servico || s.id, Number(s.quantidade || 1), Number(s.valorFinal ?? s.valor ?? 0)));
+      } else if (b.serviceValues) {
+        Object.entries(b.serviceValues).forEach(([nome, s]) => addService(nome, Number(s.quantidade || 1), Number(s.valorFinal ?? s.valor ?? 0)));
+      } else if (b.valorServicos) {
+        Object.entries(b.valorServicos).forEach(([nome, val]) => addService(nome, 1, Number(val || 0)));
+      }
+    });
+  });
+  avulsos.forEach(a => addService(a.nome || a.servico, Number(a.quantidade || 1), Number(a.valor || a.valorFinal || 0)));
+  const topServices = Array.from(serviceMap.values())
+    .sort((a,b) => b.total - a.total)
+    .slice(0,5);
+
+  // Ranking mecânicos (por valor)
+  const mechMap = new Map();
+  os.forEach(o => {
+    const mid = o.mecanicoId || o.mecanico?.id || "Sem mecânico";
+    const val = sumFromOS(o);
+    const cur = mechMap.get(mid) || { id: mid, total: 0, qty: 0 };
+    cur.total += val; cur.qty += 1; mechMap.set(mid, cur);
+  });
+  const topMechanics = Array.from(mechMap.values())
+    .sort((a,b) => b.total - a.total)
+    .slice(0,5);
+
+  return {
+    period: { start, end },
+    statusCount,
+    kpis: {
+      orders: os.length,
+      avulsos: avulsos.length,
+      revenue: totalRevenue,
+      avgTicket,
+    },
+    trend: trendDays.map(d => ({ name: d.label, value: Math.round(d.value) })),
+    mix: [
+      { name: "OS", value: Math.round(revenueOS) },
+      { name: "Avulsos", value: Math.round(revenueAvulso) },
+    ],
+    topServices,
+    topMechanics,
+  };
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,22 @@ export default {
   ],
   darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          yellow: "#FFD600",
+          black: "#0A0A0A",
+          darkBg: "#0B0B0B",
+          card: "#121212"
+        }
+      },
+      boxShadow: {
+        soft: "0 10px 30px rgba(0,0,0,0.20)",
+      },
+      borderRadius: {
+        xl2: "1rem",
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add Firestore-powered dashboard service and admin page
- style dashboard with Sport Bike yellow/black theme and new charts
- route `/admin` to the smart dashboard and tweak global styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: __dirname is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689955db10cc832eb5bc791cfc7de5e1