### PR TITLE
Permitir edição e exclusão de serviços avulsos

### DIFF
--- a/src/services/servicosAvulsos.js
+++ b/src/services/servicosAvulsos.js
@@ -1,11 +1,14 @@
 import {
   addDoc,
   collection,
+  doc,
   limit,
   onSnapshot,
   orderBy,
   query,
   serverTimestamp,
+  updateDoc,
+  deleteDoc,
   Timestamp,
   where,
 } from "firebase/firestore";
@@ -26,6 +29,23 @@ export async function createServicoAvulso({ mecanicoId, servico, quantidade, val
     // dataCriacao: serverTimestamp(), // descomente se precisar retrocompat
   };
   return addDoc(collection(db, COLL), payload);
+}
+
+/** Atualiza um serviço avulso existente */
+export async function updateServicoAvulso(id, { mecanicoId, servico, quantidade, valor, observacoes }) {
+  const payload = {
+    mecanicoId,
+    servico: (servico || "").trim(),
+    quantidade: Number(quantidade || 1),
+    valor: Number(valor || 0),
+    observacoes: (observacoes || "").trim(),
+  };
+  return updateDoc(doc(db, COLL, id), payload);
+}
+
+/** Remove um serviço avulso */
+export function deleteServicoAvulso(id) {
+  return deleteDoc(doc(db, COLL, id));
 }
 
 /** Últimos N lançamentos do mecânico (merge `data` e `dataCriacao`) */


### PR DESCRIPTION
## Summary
- adicionar funções para atualizar e remover serviços avulsos
- permitir editar e excluir serviços na tela de Serviço Rápido

## Testing
- `npx eslint src/pages/ServicoRapido.jsx src/services/servicosAvulsos.js && echo 'lint ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b2f353aaac832eb3f298791c37efeb