### PR TITLE
feat: integrate firestore genai assistant

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+
+    match /generate/{docId} {
+      allow create: if request.auth != null;
+      allow read: if request.auth != null;
+      allow update, delete: if false;
+    }
+
+    match /clientes/{id} { allow read, create, update: if request.auth != null; }
+    match /clientes/{id}/bikes/{bikeId} { allow read, create, update: if request.auth != null; }
+
+    match /ordens/{id} { allow read, create, update: if request.auth != null; }
+
+    match /servicos/{id} { allow read: if request.auth != null; }
+    match /servicosList/{id} { allow read: if request.auth != null; }
+    match /servicosAvulsos/{id} { allow read: if request.auth != null; }
+
+    match /mecanicos/{id} { allow read: if request.auth != null; }
+    match /products/{id} { allow read: if request.auth != null; }
+    match /featuredProducts/{id} { allow read: if request.auth != null; }
+    match /recibos/{id} { allow read: if request.auth != null; }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,14 @@
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^7.0.2",
-        "recharts": "^2.14.1"
+        "recharts": "^2.14.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "concurrently": "^9.2.0",
@@ -2558,6 +2560,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",
@@ -8051,6 +8060,19 @@
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-router-dom": "^7.0.2",
-    "recharts": "^2.14.1"
+    "recharts": "^2.14.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "concurrently": "^9.2.0",

--- a/src/components/AssistantChat.tsx
+++ b/src/components/AssistantChat.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+import { handleSlashCommand } from "@/modules/assistant/actions";
+import { sendToExtension, watchDocOnce } from "@/modules/assistant/genai";
+import type { ChatMessage } from "@/types";
+
+function Bubble({ msg }: { msg: ChatMessage }) {
+  const isUser = msg.role === "user";
+  return (
+    <div className={`w-full flex ${isUser ? "justify-end" : "justify-start"} my-1`}>
+      <div
+        className={`max-w-[80%] rounded-2xl px-4 py-2 shadow
+        ${isUser ? "bg-blue-600 text-white" : "bg-neutral-200 text-neutral-900"}`}
+      >
+        {msg.text.split("\n").map((line, i) => (
+          <p key={i} className="whitespace-pre-wrap text-sm leading-relaxed">
+            {line}
+          </p>
+        ))}
+        {msg.status && <div className="text-xs opacity-70 mt-1">status: {msg.status}</div>}
+      </div>
+    </div>
+  );
+}
+
+export default function AssistantChat() {
+  const [threadId] = useState(() => uuid());
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      role: "system",
+      text:
+        "Assistente Administrativo – Sport Bike. Use /help para comandos (clientes, serviços, OS, etc.).",
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  async function handleSend() {
+    const text = input.trim();
+    if (!text) return;
+
+    setInput("");
+    setMessages((prev) => [...prev, { role: "user", text }]);
+    setBusy(true);
+
+    try {
+      // 1) Slash-commands
+      if (text.startsWith("/")) {
+        const result = await handleSlashCommand(text);
+        setMessages((prev) => [...prev, { role: "assistant", text: result }]);
+        setBusy(false);
+        return;
+      }
+
+      // 2) Mensagem normal → EXTENSÃO
+      const { id } = await sendToExtension(text, threadId);
+      watchDocOnce(id, ({ response, status, errorText }) => {
+        if (status?.state === "ERROR") {
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              text: `Erro ao processar pela extensão.\n${errorText ?? ""}`.trim(),
+              status: "ERROR",
+            },
+          ]);
+        } else {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", text: response ?? "(sem resposta)" },
+          ]);
+        }
+        setBusy(false);
+      });
+    } catch (e: any) {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", text: `Falha: ${e?.message ?? e}` },
+      ]);
+      setBusy(false);
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!busy) void handleSend();
+    }
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col bg-white">
+      <header className="p-3 border-b bg-neutral-50">
+        <h1 className="text-lg font-semibold">Assistente Administrativo</h1>
+        <p className="text-xs text-neutral-500">
+          IA via extensão Firestore GenAI Chatbot · Digite /help
+        </p>
+      </header>
+
+      <div ref={listRef} className="flex-1 overflow-y-auto p-3 space-y-1">
+        {messages.map((m, i) => (
+          <Bubble key={i} msg={m} />
+        ))}
+        {busy && <div className="text-xs text-neutral-500 px-2">Processando…</div>}
+      </div>
+
+      <div className="p-3 border-t bg-neutral-50">
+        <div className="flex gap-2">
+          <input
+            className="flex-1 border rounded-xl px-3 py-2 outline-none focus:ring"
+            placeholder='Escreva aqui… ex.: /cliente get nome:"João Silva"'
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            disabled={busy}
+          />
+          <button
+            onClick={handleSend}
+            disabled={busy}
+            className="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            Enviar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AssistantSidebar.tsx
+++ b/src/components/AssistantSidebar.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { MessageSquare, X } from "lucide-react";
+import AssistantChat from "@/components/AssistantChat";
+
+export default function AssistantSidebar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-40 rounded-full bg-blue-600 text-white p-4 shadow-lg hover:bg-blue-700"
+      >
+        <MessageSquare className="w-6 h-6" />
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex">
+          <div
+            className="flex-1 bg-black/40"
+            onClick={() => setOpen(false)}
+          />
+          <div className="w-full max-w-md h-full bg-white shadow-xl flex flex-col">
+            <div className="p-2 border-b flex justify-end">
+              <button onClick={() => setOpen(false)} className="p-1 rounded hover:bg-neutral-100">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-hidden">
+              <AssistantChat />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -10,6 +10,7 @@ import {
   doc,
   updateDoc,
   serverTimestamp,
+  addDoc,
 } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { getAuth } from "firebase/auth";
@@ -29,6 +30,7 @@ const db = getFirestore(app);
 const auth = getAuth(app);
 const storage = getStorage(app);
 
+// ============ FUNÇÕES EXISTENTES (mantidas) ============
 export const updateOrderStatus = async (orderId, newStatus) => {
   try {
     const orderRef = doc(db, "ordens", orderId);
@@ -36,12 +38,9 @@ export const updateOrderStatus = async (orderId, newStatus) => {
       status: newStatus,
       dataAtualizacao: serverTimestamp(),
     };
-
-    // Registra a data de conclusão quando a ordem é marcada como pronta
     if (newStatus === "Pronto") {
       updateData.dataConclusao = serverTimestamp();
     }
-
     await updateDoc(orderRef, updateData);
     return true;
   } catch (error) {
@@ -53,33 +52,25 @@ export const updateOrderStatus = async (orderId, newStatus) => {
 export const updateOrdemURL = async (osCode, customURL) => {
   try {
     const ordensRef = collection(db, "ordens");
-    const q = query(ordensRef, where("codigo", "==", osCode));
-    const querySnapshot = await getDocs(q);
+    const qRef = query(ordensRef, where("codigo", "==", osCode));
+    const querySnapshot = await getDocs(qRef);
 
     if (!querySnapshot.empty) {
       const docRef = doc(db, "ordens", querySnapshot.docs[0].id);
       const baseURL = window.location.origin;
-      const newURL =
-        customURL || `${baseURL}/consulta?os=${osCode}`;
-
-      await updateDoc(docRef, {
-        urlOS: newURL,
-      });
+      const newURL = customURL || `${baseURL}/consulta?os=${osCode}`;
+      await updateDoc(docRef, { urlOS: newURL });
     }
   } catch (error) {
     console.error("Erro ao atualizar URL:", error);
   }
 };
 
-// Função para escutar mudanças em tempo real
-export const listenToOrders = (q, setOrdens) => {
-  return onSnapshot(q, (snapshot) => {
+export const listenToOrders = (qRef, setOrdens) => {
+  return onSnapshot(qRef, (snapshot) => {
     const ordensAtualizadas = [];
-    snapshot.forEach((doc) => {
-      ordensAtualizadas.push({
-        id: doc.id,
-        ...doc.data(),
-      });
+    snapshot.forEach((docSnap) => {
+      ordensAtualizadas.push({ id: docSnap.id, ...docSnap.data() });
     });
     setOrdens(ordensAtualizadas);
   });
@@ -88,91 +79,101 @@ export const listenToOrders = (q, setOrdens) => {
 export const consultarOS = async (tipo, valor) => {
   try {
     const osRef = collection(db, "ordens");
-    let q;
+    let qRef;
     const ordens = [];
 
     if (tipo === "telefone") {
-      if (!valor) {
-        return [];
-      }
-
+      if (!valor) return [];
       const telefoneNumerico = valor.replace(/\D/g, "");
       console.log("Buscando pelo telefone:", telefoneNumerico);
 
-      // Filtra por telefone completo ou sem DDD
-      q = telefoneNumerico.length === 9
-        ? query(
-            osRef,
-            where("cliente.telefoneSemDDD", "==", telefoneNumerico),
-            orderBy("dataCriacao", "desc"),
-          )
-        : query(
-            osRef,
-            where("cliente.telefone", "==", telefoneNumerico),
-            orderBy("dataCriacao", "desc"),
-          );
+      qRef =
+        telefoneNumerico.length === 9
+          ? query(
+              osRef,
+              where("cliente.telefoneSemDDD", "==", telefoneNumerico),
+              orderBy("dataCriacao", "desc")
+            )
+          : query(
+              osRef,
+              where("cliente.telefone", "==", telefoneNumerico),
+              orderBy("dataCriacao", "desc")
+            );
 
-      const querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc) => {
-        ordens.push({
-          id: doc.id,
-          ...doc.data(),
-        });
+      const querySnapshot = await getDocs(qRef);
+      querySnapshot.forEach((docSnap) => {
+        ordens.push({ id: docSnap.id, ...docSnap.data() });
       });
-
-      // Limita a 3 para consulta normal
       return ordens.slice(0, 3);
     } else if (tipo === "historico") {
-      if (!valor) {
-        return [];
-      }
-
+      if (!valor) return [];
       const telefoneNumerico = valor.replace(/\D/g, "");
-      q = telefoneNumerico.length === 9
-        ? query(
-            osRef,
-            where("cliente.telefoneSemDDD", "==", telefoneNumerico),
-            orderBy("dataCriacao", "desc"),
-          )
-        : query(
-            osRef,
-            where("cliente.telefone", "==", telefoneNumerico),
-            orderBy("dataCriacao", "desc"),
-          );
+      qRef =
+        telefoneNumerico.length === 9
+          ? query(
+              osRef,
+              where("cliente.telefoneSemDDD", "==", telefoneNumerico),
+              orderBy("dataCriacao", "desc")
+            )
+          : query(
+              osRef,
+              where("cliente.telefone", "==", telefoneNumerico),
+              orderBy("dataCriacao", "desc")
+            );
 
-      const querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc) => {
-        ordens.push({
-          id: doc.id,
-          ...doc.data(),
-        });
+      const querySnapshot = await getDocs(qRef);
+      querySnapshot.forEach((docSnap) => {
+        ordens.push({ id: docSnap.id, ...docSnap.data() });
       });
-
-      if (ordens.length === 0) {
-        return [];
-      }
-
+      if (ordens.length === 0) return [];
       return ordens;
     } else {
-      if (!valor) {
-        return [];
-      }
-
-      q = query(osRef, where("codigo", "==", valor));
-      const querySnapshot = await getDocs(q);
-      querySnapshot.forEach((doc) => {
-        ordens.push({
-          id: doc.id,
-          ...doc.data(),
-        });
+      if (!valor) return [];
+      qRef = query(osRef, where("codigo", "==", valor));
+      const querySnapshot = await getDocs(qRef);
+      querySnapshot.forEach((docSnap) => {
+        ordens.push({ id: docSnap.id, ...docSnap.data() });
       });
-
       return ordens;
     }
   } catch (error) {
     console.error("Erro ao consultar OS:", error);
     return [];
   }
+};
+
+// ============ NOVO: helpers da EXTENSÃO (coleção "generate") ============
+const GENERATE_COL = "generate";
+const SYSTEM_CONTEXT =
+  "Você é um assistente administrativo especializado em ciclismo e bicicletas da loja Sport Bike. Responda curto e direto.";
+
+export const extSendPrompt = async (text, threadId, extraContext) => {
+  const prompt = [
+    SYSTEM_CONTEXT,
+    extraContext ? `Contexto: ${extraContext}` : "",
+    `Usuário: ${text}`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const ref = await addDoc(collection(db, GENERATE_COL), {
+    prompt,
+    threadId,
+    createTime: serverTimestamp(),
+  });
+  return { id: ref.id };
+};
+
+export const extWatchGenerateOnce = (docId, onDone) => {
+  const unsub = onSnapshot(doc(db, GENERATE_COL, docId), (snap) => {
+    const d = snap.data();
+    if (!d) return;
+    if (d.response || d?.status?.state === "ERROR") {
+      onDone({ response: d.response, status: d.status });
+      unsub();
+    }
+  });
+  return unsub;
 };
 
 export { db, auth, storage };

--- a/src/modules/assistant/actions.ts
+++ b/src/modules/assistant/actions.ts
@@ -1,0 +1,345 @@
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  serverTimestamp,
+  where,
+} from "firebase/firestore";
+import { db } from "@/config/firebase";
+import type { Ordem } from "@/types";
+
+const COL_CLIENTES = "clientes";
+const COL_ORDENS = "ordens";
+const COL_SERVICOS = "servicos";
+const COL_SERVICOS_LIST = "servicosList";
+const COL_SERVICOS_AV = "servicosAvulsos";
+const COL_MECANICOS = "mecanicos";
+const COL_RECIBOS = "recibos";
+const COL_PRODUCTS = "products";
+const COL_FEATURED = "featuredProducts";
+
+function parseArgs(input: string): Record<string, string> {
+  const re = /(\w+):"(.*?)"|(\w+):([^\s]+)/g;
+  const out: Record<string, string> = {};
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(input))) {
+    if (m[1]) out[m[1]] = m[2];
+    else if (m[3]) out[m[3]] = m[4];
+  }
+  return out;
+}
+
+function normalizePhone(p: string | undefined) {
+  const only = (p || "").replace(/\D/g, "");
+  const last9 = only.slice(-9);
+  return { full: only, last9 };
+}
+
+async function findClienteByNome(nome: string) {
+  const qRef = query(collection(db, COL_CLIENTES), where("nome", "==", nome), limit(1));
+  const snap = await getDocs(qRef);
+  return snap.empty ? null : { id: snap.docs[0].id, data: snap.docs[0].data() as any };
+}
+
+async function findClienteByTelefone(tel: string) {
+  const { full, last9 } = normalizePhone(tel);
+  const qRef =
+    last9.length === 9
+      ? query(collection(db, COL_CLIENTES), where("telefoneSemDDD", "==", last9), limit(1))
+      : query(collection(db, COL_CLIENTES), where("telefone", "==", full), limit(1));
+  const snap = await getDocs(qRef);
+  return snap.empty ? null : { id: snap.docs[0].id, data: snap.docs[0].data() as any };
+}
+
+async function findClienteStartsWithNome(prefix: string) {
+  const end = prefix + "\uf8ff";
+  const qRef = query(
+    collection(db, COL_CLIENTES),
+    where("nome", ">=", prefix),
+    where("nome", "<=", end),
+    limit(10)
+  );
+  const snap = await getDocs(qRef);
+  return snap.docs.map((d) => ({ id: d.id, data: d.data() as any }));
+}
+
+async function findServicoByNome(nome: string): Promise<{ src: string; doc: any } | null> {
+  for (const [src, col] of [
+    ["catalogo", COL_SERVICOS],
+    ["list", COL_SERVICOS_LIST],
+    ["avulso", COL_SERVICOS_AV],
+  ] as const) {
+    const qRef = query(collection(db, col), where("nome", "==", nome), limit(1));
+    const snap = await getDocs(qRef);
+    if (!snap.empty) return { src, doc: snap.docs[0].data() };
+  }
+  return null;
+}
+
+async function addServico(nome: string, valor: number, fonte: "catalogo" | "list" | "avulso") {
+  const col =
+    fonte === "catalogo" ? COL_SERVICOS : fonte === "list" ? COL_SERVICOS_LIST : COL_SERVICOS_AV;
+  const ref = await addDoc(collection(db, col), {
+    nome,
+    valor,
+    fonte,
+    criadoEm: serverTimestamp(),
+  });
+  return ref.id;
+}
+
+async function buildServicosFromNames(list: string[]) {
+  const itens: { nome: string; valor?: number }[] = [];
+  let total = 0;
+  for (const nome of list) {
+    const found = await findServicoByNome(nome);
+    if (found?.doc) {
+      const v = Number(found.doc.valor ?? 0);
+      itens.push({ nome: found.doc.nome ?? nome, valor: isNaN(v) ? undefined : v });
+      if (!isNaN(v)) total += v;
+    } else {
+      itens.push({ nome });
+    }
+  }
+  return { itens, total };
+}
+
+function gerarCodigoOS() {
+  const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const partA = Array.from({ length: 4 }, () => letters[Math.floor(Math.random() * letters.length)]).join("");
+  const partB = Math.floor(1000 + Math.random() * 9000);
+  return `${partA}-${partB}`;
+}
+
+export async function handleSlashCommand(raw: string): Promise<string> {
+  const [cmd, ...rest] = raw.trim().slice(1).split(" ");
+  const tail = rest.join(" ").trim();
+
+  switch (cmd.toLowerCase()) {
+    case "help":
+      return `Comandos:
+/cliente get nome:"Fulano" | tel:"859..."
+/cliente find nome:"prefixo"
+/cliente add nome:"Fulano" telefone:"859..."
+/cliente bikes get clienteId:"..."
+/servico valor "Nome do Serviço"
+/servico add nome:"..." valor:123 fonte:"catalogo|list|avulso"
+/os add telefone:"859..." servicos:"rev;troca" valor:150 obs:"..."
+/mecanicos list
+/products destaque
+/products top qtde:5
+/recibo get id:"..."`;
+
+    case "cliente": {
+      const [sub, ...more] = tail.split(" ");
+      const argLine = more.join(" ").trim();
+      const args = parseArgs(argLine);
+
+      if (sub === "get") {
+        if (args.nome) {
+          const c = await findClienteByNome(args.nome);
+          if (!c) return `Cliente "${args.nome}" não encontrado.`;
+          const tel = c.data.telefone ?? "sem telefone";
+          return `Cliente: ${c.data.nome}\nTelefone: ${tel}\nId: ${c.id}`;
+        }
+        if (args.tel) {
+          const c = await findClienteByTelefone(args.tel);
+          if (!c) return `Telefone "${args.tel}" não encontrado.`;
+          return `Cliente: ${c.data.nome}\nTelefone: ${c.data.telefone ?? "-"}\nId: ${c.id}`;
+        }
+        return `Uso: /cliente get nome:"Fulano" | tel:"859..."`;
+      }
+
+      if (sub === "find") {
+        if (!args.nome) return `Uso: /cliente find nome:"prefixo"`;
+        const list = await findClienteStartsWithNome(args.nome);
+        if (!list.length) return `Nenhum cliente iniciando com "${args.nome}".`;
+        return list.map((c) => `• ${c.data.nome} (${c.data.telefone ?? "-"}) [${c.id}]`).join("\n");
+      }
+
+      if (sub === "add") {
+        if (!args.nome) return `Uso: /cliente add nome:"Fulano" telefone:"859..."`;
+        const { full, last9 } = normalizePhone(args.telefone);
+        const ref = await addDoc(collection(db, COL_CLIENTES), {
+          nome: args.nome,
+          telefone: full || null,
+          telefoneSemDDD: full ? last9 : null,
+          criadoEm: serverTimestamp(),
+        });
+        return `Cliente criado (id: ${ref.id}).`;
+      }
+
+      if (sub === "bikes") {
+        const [sub2, ...more2] = argLine.split(" ");
+        const arg2 = parseArgs(more2.join(" ").trim());
+        if (sub2 === "get") {
+          if (!arg2.clienteId) return `Uso: /cliente bikes get clienteId:"..."`;
+          const snap = await getDocs(collection(db, `${COL_CLIENTES}/${arg2.clienteId}/bikes`));
+          if (snap.empty) return `Sem bikes cadastradas para esse cliente.`;
+          return snap.docs
+            .map((d) => {
+              const b = d.data() as any;
+              return `• ${b.marca ?? ""} ${b.modelo ?? ""} aro ${b.aro ?? "?"} (${d.id})`;
+            })
+            .join("\n");
+        }
+      }
+
+      return `Comandos de cliente:\n/cliente get ... | /cliente find ... | /cliente add ... | /cliente bikes get ...`;
+    }
+
+    case "servico": {
+      const [sub, ...more] = tail.split(" ");
+      const argLine = more.join(" ").trim();
+
+      if (sub === "valor") {
+        const nome = argLine.replace(/^"|"$/g, "");
+        if (!nome) return `Uso: /servico valor "Nome do Serviço"`;
+        const found = await findServicoByNome(nome);
+        if (!found) return `Serviço "${nome}" não encontrado.`;
+        const v = Number(found.doc.valor ?? 0);
+        return `Valor de "${found.doc.nome ?? nome}" (fonte: ${found.src}): R$ ${isNaN(v) ? "—" : v.toFixed(2)}`;
+      }
+
+      if (sub === "add") {
+        const args = parseArgs(argLine);
+        if (!args.nome || !args.valor)
+          return `Uso: /servico add nome:"..." valor:123 fonte:"catalogo|list|avulso"`;
+        const fonte = (args.fonte as "catalogo" | "list" | "avulso") ?? "catalogo";
+        const id = await addServico(args.nome, Number(args.valor), fonte);
+        return `Serviço criado em ${fonte} (id: ${id}).`;
+      }
+
+      return `Comandos de serviço:\n/servico valor "Nome"\n/servico add nome:"..." valor:123 fonte:"catalogo|list|avulso"`;
+    }
+
+    case "os": {
+      const [sub, ...more] = tail.split(" ");
+      const argLine = more.join(" ").trim();
+
+      if (sub === "add") {
+        const args = parseArgs(argLine);
+        if (!args.telefone && !args.clienteId)
+          return `Informe telefone:"..." ou clienteId:"..."`;
+
+        let clienteId = args.clienteId || null;
+        let telFull: string | null = null;
+        let telLast9: string | null = null;
+
+        if (args.telefone) {
+          const norm = normalizePhone(args.telefone);
+          telFull = norm.full || null;
+          telLast9 = norm.last9 || null;
+
+          if (!clienteId && telFull) {
+            const c = await findClienteByTelefone(telFull);
+            if (c) clienteId = c.id;
+          }
+        }
+
+        const nomesServicos = (args.servicos ?? "")
+          .split(";")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const { itens, total } = await buildServicosFromNames(nomesServicos);
+
+        const valorTotal = args.valor ? Number(args.valor) : total || undefined;
+        const codigo = args.codigo || gerarCodigoOS();
+
+        const os: Ordem = {
+          status: "Pendente",
+          origem: "assistente",
+          criadoEm: undefined,
+          valorTotal,
+          observacoes: args.obs ?? args.observacoes ?? undefined,
+          servicos: itens.length ? itens : undefined,
+          // Campos extras do schema real:
+          // @ts-ignore
+          codigo,
+          // @ts-ignore
+          dataCriacao: serverTimestamp(),
+          // @ts-ignore
+          dataAtualizacao: serverTimestamp(),
+          // @ts-ignore
+          cliente: {
+            id: clienteId || null,
+            telefone: telFull || null,
+            telefoneSemDDD: telLast9 || null,
+          },
+        };
+
+        const ref = await addDoc(collection(db, COL_ORDENS), os as any);
+        return `OS criada (id: ${ref.id}) — código: ${codigo}${valorTotal ? ` — Valor: R$ ${valorTotal.toFixed(2)}` : ""}`;
+      }
+
+      return `Comandos de OS:\n/os add telefone:"859..." servicos:"rev;troca" valor:150 obs:"..."`;
+    }
+
+    case "mecanicos": {
+      const [sub] = tail.split(" ");
+      if (sub === "list") {
+        const snap = await getDocs(collection(db, COL_MECANICOS));
+        if (snap.empty) return "Nenhum mecânico cadastrado.";
+        return snap.docs
+          .map((d) => {
+            const m = d.data() as any;
+            return `• ${m.nome ?? d.id} ${m.ativo === false ? "(inativo)" : ""}`;
+          })
+          .join("\n");
+      }
+      return `Uso: /mecanicos list`;
+    }
+
+    case "products": {
+      const [sub, ...more] = tail.split(" ");
+      const args = parseArgs(more.join(" ").trim());
+
+      if (sub === "destaque") {
+        const snap = await getDocs(collection(db, COL_FEATURED));
+        if (snap.empty) return "Sem produtos em destaque.";
+        return snap.docs
+          .map((d) => {
+            const p = d.data() as any;
+            return `• ${p.nome ?? d.id} — R$ ${Number(p.preco ?? 0).toFixed(2)}`;
+          })
+          .join("\n");
+      }
+
+      if (sub === "top") {
+        const qt = Math.max(1, Number(args.qtde ?? 5));
+        const qRef = query(collection(db, COL_PRODUCTS), orderBy("preco", "desc"), limit(qt));
+        const snap = await getDocs(qRef);
+        if (snap.empty) return "Sem produtos.";
+        return snap.docs
+          .map((d) => {
+            const p = d.data() as any;
+            return `• ${p.nome ?? d.id} — R$ ${Number(p.preco ?? 0).toFixed(2)}`;
+          })
+          .join("\n");
+      }
+
+      return `Comandos de products:\n/products destaque\n/products top qtde:5`;
+    }
+
+    case "recibo": {
+      const [sub, ...more] = tail.split(" ");
+      const args = parseArgs(more.join(" ").trim());
+      if (sub === "get") {
+        if (!args.id) return `Uso: /recibo get id:"..."`;
+        const snap = await getDoc(doc(db, COL_RECIBOS, args.id));
+        if (!snap.exists()) return "Recibo não encontrado.";
+        const r = snap.data() as any;
+        return `Recibo: ${args.id}\nOS: ${r.ordemId ?? "-"}\nValor: R$ ${Number(r.valor ?? 0).toFixed(2)}`;
+      }
+      return `Uso: /recibo get id:"..."`;
+    }
+
+    default:
+      return `Digite /help para ver os comandos.`;
+  }
+}

--- a/src/modules/assistant/genai.ts
+++ b/src/modules/assistant/genai.ts
@@ -1,0 +1,39 @@
+import { addDoc, collection, doc, onSnapshot, serverTimestamp } from "firebase/firestore";
+import { db } from "@/config/firebase";
+
+const GENERATE_COL = "generate";
+
+const SYSTEM_CONTEXT = `Você é um assistente administrativo especializado em ciclismo e bicicletas da loja Sport Bike.
+Responda curto e direto. Se a pergunta for sobre dados internos, peça nome ou telefone do cliente.`;
+
+export async function sendToExtension(text: string, threadId: string, extraContext?: string) {
+  const prompt = [SYSTEM_CONTEXT, extraContext ? `Contexto: ${extraContext}` : "", `Usuário: ${text}`]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const ref = await addDoc(collection(db, GENERATE_COL), {
+    prompt,
+    threadId,
+    createTime: serverTimestamp(),
+  });
+  return { id: ref.id };
+}
+
+export function watchDocOnce(
+  docId: string,
+  onDone: (payload: { response?: string; status?: any; errorText?: string }) => void
+) {
+  const unsub = onSnapshot(doc(db, GENERATE_COL, docId), (snap) => {
+    const d = snap.data();
+    if (!d) return;
+    if (d.response || d.status?.state === "ERROR") {
+      const err =
+        d?.status?.message ||
+        d?.status?.error ||
+        (typeof d?.status === "string" ? d.status : "");
+      onDone({ response: d.response, status: d.status, errorText: err });
+      unsub();
+    }
+  });
+  return unsub;
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -23,6 +23,7 @@ import {
 } from "../services/dashboardService";
 import { auth } from "../config/firebase";
 import { signOut } from "firebase/auth";
+import AssistantSidebar from "@/components/AssistantSidebar";
 
 export default function Admin() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -297,6 +298,7 @@ export default function Admin() {
             </div>
           </div>
         </footer>
+        <AssistantSidebar />
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export type ChatMessage = {
+  id?: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+  createTime?: any;
+  status?: string;
+  error?: string;
+};
+
+export type Cliente = {
+  nome: string;
+  telefone?: string;
+  telefoneSemDDD?: string;
+  criadoEm?: any;
+};
+
+export type Servico = {
+  nome: string;
+  valor?: number;
+  fonte?: "catalogo" | "list" | "avulso";
+};
+
+export type Ordem = {
+  clienteId?: string | null;
+  telefone?: string | null;
+  servicos?: { nome: string; valor?: number }[];
+  valorTotal?: number;
+  observacoes?: string;
+  status?: "aberta" | "em_andamento" | "concluida" | "Pendente";
+  origem?: "assistente";
+  criadoEm?: any;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Firestore GenAI helpers and chat modules
- introduce assistant sidebar and chat UI in admin
- define Firestore rules and TypeScript models

## Testing
- `npm run lint` *(fails: 'orderBy' is defined but never used, 185 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b318200854832e988c62373a89437e